### PR TITLE
fix: address PR review feedback on search API + about page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,16 +1,9 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Tag, Photo, Avatar, ManCard } from "@/components/man/primitives";
+import { Tag, Photo } from "@/components/man/primitives";
 import { SiteFooter } from "@/components/site-footer";
 
 const ABOUT_IMG = "https://images.unsplash.com/photo-1578916171728-46686eac8d58?auto=format&fit=crop&w=900&q=70";
-
-const team = [
-  { n: "Aisha Mahmood", r: "Co-founder, CEO" },
-  { n: "Bilal Rahman", r: "Co-founder, CTO" },
-  { n: "Sana Patel", r: "Head of Verification" },
-  { n: "Omar Idris", r: "Head of Community" },
-];
 
 export default function AboutPage() {
   return (
@@ -34,20 +27,6 @@ export default function AboutPage() {
             </p>
             <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginTop: 28 }}>Founded</div>
             <div className="t-body" style={{ color: "var(--ink-700)", marginTop: 4 }}>Started in Sacramento, growing city by city across California.</div>
-          </div>
-        </div>
-
-        <div className="mt-14">
-          <div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>Team</div>
-          <h2 className="t-h2" style={{ color: "var(--ink-900)", marginTop: 6 }}>Built by People Who Needed It.</h2>
-          <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
-            {team.map((p) => (
-              <ManCard key={p.n} style={{ padding: 18 }}>
-                <Avatar name={p.n} size={48} />
-                <div className="t-label" style={{ color: "var(--ink-900)", marginTop: 12 }}>{p.n}</div>
-                <div className="t-body-xs" style={{ color: "var(--ink-500)", marginTop: 2 }}>{p.r}</div>
-              </ManCard>
-            ))}
           </div>
         </div>
 

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -2,6 +2,11 @@ import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { db, isMockMode } from "@/lib/db";
+import { DEFAULT_LOCATION } from "@/lib/constants";
+
+// Guards against pathological input (huge query strings / term explosions)
+const MAX_QUERY_LENGTH = 200;
+const MAX_SEARCH_TERMS = 12;
 
 // GET /api/search - Enhanced search with NLP-like features
 export async function GET(req: Request) {
@@ -9,14 +14,23 @@ export async function GET(req: Request) {
     const session = await auth();
     const { searchParams } = new URL(req.url);
 
-    const query = searchParams.get("q") || "";
+    // Cap query length so a pathological input can't blow up parsing/filtering
+    const query = (searchParams.get("q") || "").slice(0, MAX_QUERY_LENGTH);
     const category = searchParams.get("category");
     const tags = searchParams.get("tags")?.split(",").filter(Boolean);
     const priceRange = searchParams.get("priceRange");
     const verified = searchParams.get("verified") === "true";
     const openNow = searchParams.get("openNow") === "true";
-    const lat = parseFloat(searchParams.get("lat") || "38.5816");
-    const lng = parseFloat(searchParams.get("lng") || "-121.4944");
+    const minRating = parseFloat(searchParams.get("minRating") || "0") || 0;
+
+    // Only filter by distance when the caller actually provided a location.
+    // Otherwise fall back to the default service-area center (Sacramento) for
+    // distance display/sort, but don't constrain results to a radius around it.
+    const latParam = searchParams.get("lat");
+    const lngParam = searchParams.get("lng");
+    const hasLocation = latParam !== null && lngParam !== null;
+    const lat = hasLocation ? parseFloat(latParam) : DEFAULT_LOCATION.latitude;
+    const lng = hasLocation ? parseFloat(lngParam) : DEFAULT_LOCATION.longitude;
     const radius = parseFloat(searchParams.get("radius") || "10"); // miles
     const sortBy = searchParams.get("sortBy") || "relevance";
     const page = parseInt(searchParams.get("page") || "1");
@@ -57,7 +71,7 @@ export async function GET(req: Request) {
       });
     }
 
-    // Distance + radius filter
+    // Distance + radius + rating filter
     let results = candidates
       .map((b: any) => ({
         ...b,
@@ -65,7 +79,12 @@ export async function GET(req: Request) {
         reviewCount: b.totalReviews || 0,
         isOpen: openNow ? isBusinessOpen(b.hours) : undefined,
       }))
-      .filter((b: any) => b.distance <= radius);
+      .filter((b: any) => {
+        // Only constrain by radius when the caller supplied a location
+        if (hasLocation && b.distance > radius) return false;
+        if (minRating > 0 && (b.averageRating || 0) < minRating) return false;
+        return true;
+      });
 
     // Sort
     if (sortBy === "distance") {
@@ -220,6 +239,7 @@ function parseNaturalLanguageQuery(query: string): {
 
   const words = query.toLowerCase().split(/\s+/);
   for (const word of words) {
+    if (searchTerms.length >= MAX_SEARCH_TERMS) break;
     if (!stopWords.has(word) && word.length > 2) {
       searchTerms.push(word);
     }


### PR DESCRIPTION
Addresses the review comments left on PR #1.

## Search API (`app/api/search/route.ts`)
- **Hardcoded coordinates** → now reuses the existing `DEFAULT_LOCATION` constant. The radius filter is only applied when the caller actually provides `lat`/`lng`, so queries without a location are no longer silently constrained to a 10mi radius around Sacramento.
- **minRating** → added support for a `minRating` query param, applied in the results filter.
- **Search term cap** → query string capped at 200 chars and search terms capped at 12, to guard against pathological input in production.

## About page (`app/about/page.tsx`)
- Removed the placeholder "Built by People Who Needed It" team section (fictional names) and the now-unused `team` array / `Avatar` / `ManCard` imports.

## Verification
- `tsc --noEmit` clean
- `npm run build` compiles successfully; all 89 pages generate without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)