### PR TITLE
Design consistency: search polish + design system (P0 + P1)

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -18,7 +18,7 @@ export default function AboutPage() {
         </p>
 
         <div className="mt-14 grid items-start gap-8 md:grid-cols-2">
-          <Photo src={ABOUT_IMG} alt="Founders" h={320} radius={14} />
+          <Photo src={ABOUT_IMG} alt="Founders" h={320} radius={12} />
           <div>
             <div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>Mission</div>
             <h2 className="t-h2" style={{ color: "var(--ink-900)", marginTop: 8 }}>Trust, Made Visible.</h2>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -10,10 +10,10 @@ export default function AboutPage() {
     <div style={{ background: "var(--paper)" }}>
       <div className="mx-auto max-w-[1100px] px-6 py-16">
         <Tag tone="moss">Our Story</Tag>
-        <h1 className="t-h1" style={{ color: "var(--ink-900)", marginTop: 14, fontSize: 50, maxWidth: 720 }}>
+        <h1 className="t-h1" style={{ color: "var(--ink-900)", marginTop: 12, fontSize: 50, maxWidth: 720 }}>
           We started Manaakhah because finding Muslim-owned businesses you can trust shouldn&apos;t feel like detective work.
         </h1>
-        <p className="t-body-lg" style={{ color: "var(--ink-500)", marginTop: 18, maxWidth: 640 }}>
+        <p className="t-body-lg" style={{ color: "var(--ink-500)", marginTop: 16, maxWidth: 640 }}>
           For most Muslim families, finding trustworthy Muslim-owned businesses in a new city means a chain of WhatsApp messages, phone calls, and crossed fingers. We&apos;re building the directory that makes it simple to find, support, and do business within the community.
         </p>
 
@@ -44,7 +44,7 @@ export default function AboutPage() {
       <section style={{ background: "var(--moss-700)", color: "var(--bone)" }}>
         <div className="mx-auto max-w-[1100px] px-6 py-12 text-center">
           <h2 className="t-h2" style={{ color: "var(--bone)" }}>Find Businesses You Can Trust.</h2>
-          <p style={{ marginTop: 10, opacity: 0.85, fontSize: 15 }}>Join the community supporting Muslim-owned businesses across Sacramento.</p>
+          <p style={{ marginTop: 8, opacity: 0.85, fontSize: 15 }}>Join the community supporting Muslim-owned businesses across Sacramento.</p>
           <div className="mt-6 flex justify-center gap-2.5">
             <Link href="/register"><Button size="lg" style={{ background: "var(--bone)", color: "var(--moss-800)" }}>Sign Up Free</Button></Link>
             <Link href="/search"><Button size="lg" variant="ghost" style={{ color: "var(--bone)", border: "1px solid rgba(255,255,255,0.25)" }}>Explore Businesses</Button></Link>

--- a/app/account/lists/page.tsx
+++ b/app/account/lists/page.tsx
@@ -37,7 +37,7 @@ export default function SavedListsPage() {
               </div>
             </ManCard>
           ))}
-          <button className="flex min-h-[200px] flex-col items-center justify-center gap-2 rounded-[14px]" style={{ border: "2px dashed var(--card-edge)", color: "var(--ink-500)" }}>
+          <button className="man-focus flex min-h-[200px] flex-col items-center justify-center gap-2 rounded-[14px]" style={{ border: "2px dashed var(--card-edge)", color: "var(--ink-500)" }}>
             <Plus size={22} /><span className="t-label">Create a new list</span>
           </button>
         </div>
@@ -66,7 +66,7 @@ export default function SavedListsPage() {
                   <div className="t-body-xs" style={{ color: "var(--ink-500)", marginTop: 2 }}>Personal note: must try the mixed grill</div>
                 </div>
                 {b.averageRating > 0 && <Rating value={b.averageRating} count={b.reviewCount} />}
-                <button style={{ color: "var(--ink-400)" }}><MoreHorizontal size={18} /></button>
+                <button className="man-focus rounded-lg p-1" style={{ color: "var(--ink-400)" }}><MoreHorizontal size={18} /></button>
               </div>
             ))}
           </ManCard>

--- a/app/account/lists/page.tsx
+++ b/app/account/lists/page.tsx
@@ -37,7 +37,7 @@ export default function SavedListsPage() {
               </div>
             </ManCard>
           ))}
-          <button className="man-focus flex min-h-[200px] flex-col items-center justify-center gap-2 rounded-[14px]" style={{ border: "2px dashed var(--card-edge)", color: "var(--ink-500)" }}>
+          <button className="man-focus flex min-h-[200px] flex-col items-center justify-center gap-2 rounded-[12px]" style={{ border: "2px dashed var(--card-edge)", color: "var(--ink-500)" }}>
             <Plus size={22} /><span className="t-label">Create a new list</span>
           </button>
         </div>

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -43,7 +43,7 @@ export default function AccountHome() {
           <PH title="Recent Activity" />
           <ManCard>
             {activity.map((a, i) => (
-              <Link key={i} href={a.href} className="flex items-center gap-3.5 px-[18px] py-3.5"
+              <Link key={i} href={a.href} className="flex items-center gap-3.5 px-5 py-3.5"
                 style={{ borderBottom: i === activity.length - 1 ? "none" : "1px solid var(--card-edge)" }}>
                 <div className="flex h-8 w-8 items-center justify-center rounded-full" style={{ background: "var(--moss-50)" }}>
                   <a.Icon size={14} style={{ color: "var(--moss-700)" }} />

--- a/app/account/searches/page.tsx
+++ b/app/account/searches/page.tsx
@@ -15,7 +15,7 @@ const initial = [
 
 function Toggle({ on, onClick }: { on: boolean; onClick: () => void }) {
   return (
-    <button onClick={onClick} className="relative h-5 w-9 rounded-full transition-colors" style={{ background: on ? "var(--moss-700)" : "var(--paper-3)" }}>
+    <button onClick={onClick} className="man-focus relative h-5 w-9 rounded-full transition-colors" style={{ background: on ? "var(--moss-700)" : "var(--paper-3)" }}>
       <span className="absolute top-0.5 h-4 w-4 rounded-full bg-white transition-all" style={{ left: on ? 18 : 2 }} />
     </button>
   );
@@ -42,8 +42,8 @@ export default function SavedSearchesPage() {
                 <Toggle on={r.notify} onClick={() => setRows((p) => p.map((x, j) => (j === i ? { ...x, notify: !x.notify } : x)))} />
               </div>
               <div className="flex items-center gap-1">
-                <button className="rounded-lg p-2 hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-500)" }}><Pencil size={16} /></button>
-                <button onClick={() => setRows((p) => p.filter((_, j) => j !== i))} className="rounded-lg p-2 hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-500)" }}><Trash2 size={16} /></button>
+                <button className="man-focus rounded-lg p-2 hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-500)" }}><Pencil size={16} /></button>
+                <button onClick={() => setRows((p) => p.filter((_, j) => j !== i))} className="man-focus rounded-lg p-2 hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-500)" }}><Trash2 size={16} /></button>
               </div>
             </div>
           ))}

--- a/app/account/settings/page.tsx
+++ b/app/account/settings/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 
 function Toggle({ on, onClick }: { on: boolean; onClick: () => void }) {
   return (
-    <button onClick={onClick} className="relative h-5 w-9 rounded-full transition-colors" style={{ background: on ? "var(--moss-700)" : "var(--paper-3)" }} aria-pressed={on}>
+    <button onClick={onClick} className="man-focus relative h-5 w-9 rounded-full transition-colors" style={{ background: on ? "var(--moss-700)" : "var(--paper-3)" }} aria-pressed={on}>
       <span className="absolute top-0.5 h-4 w-4 rounded-full bg-white transition-all" style={{ left: on ? 18 : 2 }} />
     </button>
   );

--- a/app/admin/businesses/[id]/page.tsx
+++ b/app/admin/businesses/[id]/page.tsx
@@ -72,7 +72,7 @@ export default function VerificationDetailPage() {
           <div className="grid gap-3.5">
             <ManCard style={{ padding: 22 }}>
               <div className="t-h4" style={{ color: "var(--ink-900)" }}>Decision</div>
-              <textarea placeholder="Add a note (sent to the owner if rejected)…" className="mt-3 w-full rounded-[10px] border bg-white px-3 py-2.5 t-body-sm outline-none" style={{ borderColor: "var(--card-edge)", color: "var(--ink-900)", minHeight: 80, resize: "vertical" }} />
+              <textarea placeholder="Add a note (sent to the owner if rejected)…" className="man-field mt-3 w-full px-3 py-2.5 t-body-sm" style={{ color: "var(--ink-900)", minHeight: 80, resize: "vertical" }} />
               <div className="mt-3 grid gap-2">
                 <Button onClick={() => setDecision("approved")}><Check className="mr-1.5 h-4 w-4" /> Approve & Issue Seal</Button>
                 <Button variant="outline" size="sm" onClick={() => setDecision("rejected")} style={{ color: "var(--err-500)", borderColor: "var(--err-500)" }}><X className="mr-1.5 h-4 w-4" /> Reject</Button>

--- a/app/admin/businesses/[id]/page.tsx
+++ b/app/admin/businesses/[id]/page.tsx
@@ -46,7 +46,7 @@ export default function VerificationDetailPage() {
         <div className="mt-5 grid gap-3.5 lg:grid-cols-[1.5fr_1fr]">
           {/* Checks */}
           <div className="grid gap-3.5">
-            <ManCard style={{ padding: 22 }}>
+            <ManCard style={{ padding: 20 }}>
               <div className="flex items-baseline justify-between"><div className="t-h4" style={{ color: "var(--ink-900)" }}>Automated Checks</div><span className="t-body-sm" style={{ color: passed === CHECKS.length ? "var(--moss-700)" : "var(--clay-700)" }}>{passed}/{CHECKS.length} passed</span></div>
               <div className="mt-3.5 grid gap-2.5">
                 {CHECKS.map((c) => (
@@ -58,7 +58,7 @@ export default function VerificationDetailPage() {
               </div>
             </ManCard>
 
-            <ManCard style={{ padding: 22 }}>
+            <ManCard style={{ padding: 20 }}>
               <div className="t-h4" style={{ color: "var(--ink-900)" }}>Submitted Certificate</div>
               <div className="mt-3 flex items-center gap-3 rounded-[8px] p-3.5" style={{ background: "var(--paper-2)" }}>
                 <FileText size={22} style={{ color: "var(--ink-700)" }} />
@@ -70,7 +70,7 @@ export default function VerificationDetailPage() {
 
           {/* Decision + meta */}
           <div className="grid gap-3.5">
-            <ManCard style={{ padding: 22 }}>
+            <ManCard style={{ padding: 20 }}>
               <div className="t-h4" style={{ color: "var(--ink-900)" }}>Decision</div>
               <textarea placeholder="Add a note (sent to the owner if rejected)…" className="man-field mt-3 w-full px-3 py-2.5 t-body-sm" style={{ color: "var(--ink-900)", minHeight: 80, resize: "vertical" }} />
               <div className="mt-3 grid gap-2">
@@ -80,7 +80,7 @@ export default function VerificationDetailPage() {
               </div>
             </ManCard>
 
-            <ManCard style={{ padding: 22 }}>
+            <ManCard style={{ padding: 20 }}>
               <div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>Business details</div>
               <div className="mt-3 grid gap-2.5 t-body-sm" style={{ color: "var(--ink-700)" }}>
                 <div className="flex items-center gap-2"><MapPin size={14} style={{ color: "var(--ink-400)" }} /> 1290 Fulton Ave, Sacramento, CA</div>

--- a/app/admin/businesses/[id]/page.tsx
+++ b/app/admin/businesses/[id]/page.tsx
@@ -27,7 +27,7 @@ export default function VerificationDetailPage() {
 
         <div className="mt-3 flex flex-wrap items-start justify-between gap-3">
           <div className="flex items-center gap-3.5">
-            <Photo seed="sac-famous-kabob" w={64} h={56} radius={10} />
+            <Photo seed="sac-famous-kabob" w={64} h={56} radius={8} />
             <div>
               <div className="flex items-center gap-2"><h1 className="t-h3" style={{ color: "var(--ink-900)" }}>Famous Kabob</h1><Tag tone="warn">Pending</Tag></div>
               <div className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 2 }}>Restaurant · HFSAA · submitted 4h ago by Yusuf A.</div>
@@ -60,7 +60,7 @@ export default function VerificationDetailPage() {
 
             <ManCard style={{ padding: 22 }}>
               <div className="t-h4" style={{ color: "var(--ink-900)" }}>Submitted Certificate</div>
-              <div className="mt-3 flex items-center gap-3 rounded-[10px] p-3.5" style={{ background: "var(--paper-2)" }}>
+              <div className="mt-3 flex items-center gap-3 rounded-[8px] p-3.5" style={{ background: "var(--paper-2)" }}>
                 <FileText size={22} style={{ color: "var(--ink-700)" }} />
                 <div className="flex-1"><div className="t-label-sm" style={{ color: "var(--ink-900)" }}>HFSAA_cert_2026.pdf</div><div className="t-body-xs" style={{ color: "var(--ink-500)" }}>Issued by Halal Food Standards Alliance of America</div></div>
                 <Button variant="outline" size="sm">Open</Button>

--- a/app/admin/businesses/review-queue/page.tsx
+++ b/app/admin/businesses/review-queue/page.tsx
@@ -38,7 +38,7 @@ export default function VerificationQueuePage() {
             <button key={f} onClick={() => setFilter(f)} className="man-focus t-body-sm rounded-full px-3 py-1.5"
               style={filter === f ? { background: "var(--moss-700)", color: "var(--bone)" } : { background: "var(--card)", border: "1px solid var(--card-edge)", color: "var(--ink-700)" }}>{f}</button>
           ))}
-          <div className="man-field-wrap ml-auto flex items-center gap-2 rounded-[10px] border bg-white px-3 py-1.5">
+          <div className="man-field-wrap ml-auto flex items-center gap-2 rounded-[8px] border bg-white px-3 py-1.5">
             <Search size={15} style={{ color: "var(--ink-400)" }} /><input placeholder="Search business" className="w-40 bg-transparent t-body-sm outline-none" style={{ color: "var(--ink-900)" }} />
           </div>
         </div>

--- a/app/admin/businesses/review-queue/page.tsx
+++ b/app/admin/businesses/review-queue/page.tsx
@@ -38,7 +38,7 @@ export default function VerificationQueuePage() {
             <button key={f} onClick={() => setFilter(f)} className="t-body-sm rounded-full px-3 py-1.5"
               style={filter === f ? { background: "var(--ink-900)", color: "var(--bone)" } : { background: "var(--card)", border: "1px solid var(--card-edge)", color: "var(--ink-700)" }}>{f}</button>
           ))}
-          <div className="ml-auto flex items-center gap-2 rounded-[10px] border bg-white px-3 py-1.5" style={{ borderColor: "var(--card-edge)" }}>
+          <div className="man-field-wrap ml-auto flex items-center gap-2 rounded-[10px] border bg-white px-3 py-1.5">
             <Search size={15} style={{ color: "var(--ink-400)" }} /><input placeholder="Search business" className="w-40 bg-transparent t-body-sm outline-none" style={{ color: "var(--ink-900)" }} />
           </div>
         </div>

--- a/app/admin/businesses/review-queue/page.tsx
+++ b/app/admin/businesses/review-queue/page.tsx
@@ -35,8 +35,8 @@ export default function VerificationQueuePage() {
 
         <div className="my-5 flex flex-wrap items-center gap-2">
           {FILTERS.map((f) => (
-            <button key={f} onClick={() => setFilter(f)} className="t-body-sm rounded-full px-3 py-1.5"
-              style={filter === f ? { background: "var(--ink-900)", color: "var(--bone)" } : { background: "var(--card)", border: "1px solid var(--card-edge)", color: "var(--ink-700)" }}>{f}</button>
+            <button key={f} onClick={() => setFilter(f)} className="man-focus t-body-sm rounded-full px-3 py-1.5"
+              style={filter === f ? { background: "var(--moss-700)", color: "var(--bone)" } : { background: "var(--card)", border: "1px solid var(--card-edge)", color: "var(--ink-700)" }}>{f}</button>
           ))}
           <div className="man-field-wrap ml-auto flex items-center gap-2 rounded-[10px] border bg-white px-3 py-1.5">
             <Search size={15} style={{ color: "var(--ink-400)" }} /><input placeholder="Search business" className="w-40 bg-transparent t-body-sm outline-none" style={{ color: "var(--ink-900)" }} />

--- a/app/admin/cert-sources/page.tsx
+++ b/app/admin/cert-sources/page.tsx
@@ -45,7 +45,7 @@ export default function CertSourcesPage() {
                 <span className="t-body-sm" style={{ color: "var(--ink-700)" }}>{s.certs}</span>
                 <div className="flex items-center gap-2 md:ml-0 ml-auto">
                   <span className="t-body-sm" style={{ color: "var(--ink-500)" }}>{s.last}</span>
-                  <button className="rounded-lg p-1.5 hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-500)" }}><RefreshCw size={15} /></button>
+                  <button className="man-focus rounded-lg p-1.5 hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-500)" }}><RefreshCw size={15} /></button>
                 </div>
               </div>
             </div>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -30,7 +30,7 @@ export default function AdminHomePage() {
           <div className="grid gap-3">
             {QUEUES.map((q) => (
               <Link key={q.t} href={q.href}>
-                <ManCard style={{ padding: 18 }} className="flex items-center gap-4">
+                <ManCard style={{ padding: 20 }} className="flex items-center gap-4">
                   <span className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl" style={{ background: "var(--paper-2)" }}><q.Icon size={20} style={{ color: "var(--ink-700)" }} /></span>
                   <div className="flex-1">
                     <div className="flex items-center gap-2"><span className="t-label" style={{ color: "var(--ink-900)" }}>{q.t}</span><Tag tone={q.tone}>{q.badge}</Tag></div>
@@ -42,7 +42,7 @@ export default function AdminHomePage() {
             ))}
           </div>
 
-          <ManCard style={{ padding: 22 }}>
+          <ManCard style={{ padding: 20 }}>
             <div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>Seals issued</div>
             <div className="t-h3" style={{ color: "var(--ink-900)", marginTop: 4 }}>Last 14 Days</div>
             <div className="mt-4"><MiniLine data={[6, 9, 7, 12, 10, 14, 11, 16, 13, 18, 15, 20, 17, 22]} height={180} /></div>

--- a/app/admin/reviews/page.tsx
+++ b/app/admin/reviews/page.tsx
@@ -66,7 +66,7 @@ export default function ContentModerationPage() {
           {rows.length === 0 && (
             <ManCard style={{ padding: 40 }} className="text-center">
               <Check size={28} style={{ color: "var(--moss-700)", margin: "0 auto" }} />
-              <div className="t-h4" style={{ color: "var(--ink-900)", marginTop: 10 }}>Queue Clear</div>
+              <div className="t-h4" style={{ color: "var(--ink-900)", marginTop: 8 }}>Queue Clear</div>
               <div className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 4 }}>No flagged reviews match this filter.</div>
             </ManCard>
           )}

--- a/app/admin/reviews/page.tsx
+++ b/app/admin/reviews/page.tsx
@@ -33,8 +33,8 @@ export default function ContentModerationPage() {
 
         <div className="my-5 flex flex-wrap gap-2">
           {FILTERS.map((f) => (
-            <button key={f} onClick={() => setFilter(f)} className="t-body-sm rounded-full px-3 py-1.5"
-              style={filter === f ? { background: "var(--ink-900)", color: "var(--bone)" } : { background: "var(--card)", border: "1px solid var(--card-edge)", color: "var(--ink-700)" }}>{f}</button>
+            <button key={f} onClick={() => setFilter(f)} className="man-focus t-body-sm rounded-full px-3 py-1.5"
+              style={filter === f ? { background: "var(--moss-700)", color: "var(--bone)" } : { background: "var(--card)", border: "1px solid var(--card-edge)", color: "var(--ink-700)" }}>{f}</button>
           ))}
         </div>
 

--- a/app/admin/support/page.tsx
+++ b/app/admin/support/page.tsx
@@ -65,7 +65,7 @@ export default function OwnerSupportPage() {
             <div className="flex-1 space-y-3 p-5" style={{ minHeight: 220 }}>
               {active.thread.map((m, i) => (
                 <div key={i} className={`flex ${m.me ? "justify-end" : "justify-start"}`}>
-                  <div className="max-w-[80%] rounded-[14px] px-3.5 py-2.5" style={m.me ? { background: "var(--moss-700)", color: "var(--bone)" } : { background: "var(--paper-2)", color: "var(--ink-900)" }}>
+                  <div className="max-w-[80%] rounded-[12px] px-3.5 py-2.5" style={m.me ? { background: "var(--moss-700)", color: "var(--bone)" } : { background: "var(--paper-2)", color: "var(--ink-900)" }}>
                     <div className="t-body-sm">{m.t}</div>
                     <div className="t-body-xs mt-1" style={{ color: m.me ? "rgba(255,255,255,0.7)" : "var(--ink-400)" }}>{m.time}</div>
                   </div>

--- a/app/admin/support/page.tsx
+++ b/app/admin/support/page.tsx
@@ -73,7 +73,7 @@ export default function OwnerSupportPage() {
               ))}
             </div>
             <div className="flex items-end gap-2 p-4" style={{ borderTop: "1px solid var(--card-edge)" }}>
-              <textarea value={draft} onChange={(e) => setDraft(e.target.value)} placeholder="Reply to owner…" className="flex-1 rounded-[12px] border bg-white px-3.5 py-2.5 t-body-sm outline-none" style={{ borderColor: "var(--card-edge)", color: "var(--ink-900)", minHeight: 44, resize: "none" }} />
+              <textarea value={draft} onChange={(e) => setDraft(e.target.value)} placeholder="Reply to owner…" className="man-field flex-1 px-3.5 py-2.5 t-body-sm" style={{ color: "var(--ink-900)", minHeight: 44, resize: "none" }} />
               <Button size="sm"><Send className="h-4 w-4" /></Button>
               <Button variant="outline" size="sm">Resolve</Button>
             </div>

--- a/app/admin/system/page.tsx
+++ b/app/admin/system/page.tsx
@@ -50,7 +50,7 @@ export default function SystemHealthPage() {
           </ManCard>
 
           {/* Traffic chart */}
-          <ManCard style={{ padding: 22 }}>
+          <ManCard style={{ padding: 20 }}>
             <div className="flex items-baseline justify-between">
               <div><div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>Requests / min</div><div className="t-h3" style={{ color: "var(--ink-900)", marginTop: 4 }}>Last 24 Hours</div></div>
               <span className="inline-flex items-center gap-1 t-body-sm" style={{ color: "var(--moss-700)" }}><CheckCircle2 size={14} /> Healthy</span>
@@ -60,7 +60,7 @@ export default function SystemHealthPage() {
         </div>
 
         {/* Incidents */}
-        <ManCard style={{ padding: 0, marginTop: 14 }}>
+        <ManCard style={{ padding: 0, marginTop: 12 }}>
           <div className="px-5 py-3.5 t-h4" style={{ color: "var(--ink-900)", borderBottom: "1px solid var(--card-edge)" }}>Recent Incidents</div>
           {INCIDENTS.map((inc, i) => (
             <div key={inc.t} className="flex items-center gap-3 px-5 py-3.5" style={{ borderBottom: i === INCIDENTS.length - 1 ? "none" : "1px solid var(--card-edge)" }}>

--- a/app/business/[id]/certification/page.tsx
+++ b/app/business/[id]/certification/page.tsx
@@ -74,7 +74,7 @@ export default function CertificationPage() {
               <div className="t-h4" style={{ color: "var(--ink-900)", marginTop: 10 }}>How We Verify</div>
               <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 6 }}>We sync certification data nightly from the certifying body and remove badges within 24h if a certification lapses.</p>
             </ManCard>
-            <div className="rounded-[14px] p-5" style={{ background: "var(--clay-50)", border: "1px solid var(--clay-100)" }}>
+            <div className="rounded-[12px] p-5" style={{ background: "var(--clay-50)", border: "1px solid var(--clay-100)" }}>
               <div className="t-h4" style={{ color: "var(--clay-700)" }}>Have Concerns?</div>
               <p className="t-body-sm" style={{ color: "var(--ink-700)", marginTop: 6 }}>If something looks off, report it — halal disputes are reviewed within 48 hours.</p>
             </div>

--- a/app/business/[id]/certification/page.tsx
+++ b/app/business/[id]/certification/page.tsx
@@ -71,12 +71,12 @@ export default function CertificationPage() {
           <div className="space-y-4">
             <ManCard style={{ padding: 20 }}>
               <ShieldCheck size={20} style={{ color: "var(--moss-700)" }} />
-              <div className="t-h4" style={{ color: "var(--ink-900)", marginTop: 10 }}>How We Verify</div>
-              <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 6 }}>We sync certification data nightly from the certifying body and remove badges within 24h if a certification lapses.</p>
+              <div className="t-h4" style={{ color: "var(--ink-900)", marginTop: 8 }}>How We Verify</div>
+              <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 4 }}>We sync certification data nightly from the certifying body and remove badges within 24h if a certification lapses.</p>
             </ManCard>
             <div className="rounded-[12px] p-5" style={{ background: "var(--clay-50)", border: "1px solid var(--clay-100)" }}>
               <div className="t-h4" style={{ color: "var(--clay-700)" }}>Have Concerns?</div>
-              <p className="t-body-sm" style={{ color: "var(--ink-700)", marginTop: 6 }}>If something looks off, report it — halal disputes are reviewed within 48 hours.</p>
+              <p className="t-body-sm" style={{ color: "var(--ink-700)", marginTop: 4 }}>If something looks off, report it — halal disputes are reviewed within 48 hours.</p>
             </div>
           </div>
         </div>

--- a/app/business/[id]/contact/page.tsx
+++ b/app/business/[id]/contact/page.tsx
@@ -27,7 +27,7 @@ export default function ContactPage() {
         <Link href={`/business/${id}`} className="t-body-sm inline-flex items-center gap-1" style={{ color: "var(--ink-500)" }}>
           <ArrowLeft size={14} /> Back to {name}
         </Link>
-        <h1 className="t-h2" style={{ color: "var(--ink-900)", marginTop: 14 }}>Message {name}</h1>
+        <h1 className="t-h2" style={{ color: "var(--ink-900)", marginTop: 12 }}>Message {name}</h1>
 
         {sent ? (
           <ManCard style={{ padding: 40, marginTop: 24, textAlign: "center" }} className="mx-auto max-w-[520px]">
@@ -71,18 +71,18 @@ export default function ContactPage() {
 
           {/* Aside */}
           <div className="space-y-4">
-            <ManCard style={{ padding: 18 }} className="flex items-center gap-3">
+            <ManCard style={{ padding: 20 }} className="flex items-center gap-3">
               <Seal size={36} />
               <div>
                 <div className="t-label" style={{ color: "var(--ink-900)" }}>{name}</div>
                 <div className="t-body-xs" style={{ color: "var(--ink-500)" }}>{biz ? `${biz.city}, ${biz.state}` : "Sacramento, CA"}</div>
               </div>
             </ManCard>
-            <ManCard style={{ padding: 18 }}>
+            <ManCard style={{ padding: 20 }}>
               <div className="flex items-center gap-2 t-label" style={{ color: "var(--ink-900)" }}><Clock size={15} style={{ color: "var(--moss-700)" }} /> Replies in ~2 hours</div>
-              <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 6 }}>92% of messages answered within a day.</p>
+              <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 4 }}>92% of messages answered within a day.</p>
             </ManCard>
-            <ManCard style={{ padding: 18 }}>
+            <ManCard style={{ padding: 20 }}>
               <div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>Other ways to reach</div>
               <div className="mt-3 space-y-2">
                 <a href={biz?.phone ? `tel:${biz.phone}` : undefined} className="flex items-center gap-2 t-body-sm" style={{ color: "var(--ink-700)" }}><Phone size={15} style={{ color: "var(--moss-700)" }} /> {biz?.phone || "Call the business"}</a>

--- a/app/business/[id]/contact/page.tsx
+++ b/app/business/[id]/contact/page.tsx
@@ -48,8 +48,8 @@ export default function ContactPage() {
             <div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>What's this about?</div>
             <div className="mt-2 flex flex-wrap gap-2">
               {purposes.map((p) => (
-                <button key={p} onClick={() => setPurpose(p)} className="t-body-sm rounded-full px-3 py-1.5"
-                  style={purpose === p ? { background: "var(--ink-900)", color: "var(--bone)" } : { background: "var(--paper-2)", color: "var(--ink-700)" }}>{p}</button>
+                <button key={p} onClick={() => setPurpose(p)} className="man-focus t-body-sm rounded-full px-3 py-1.5"
+                  style={purpose === p ? { background: "var(--moss-700)", color: "var(--bone)" } : { background: "var(--paper-2)", color: "var(--ink-700)" }}>{p}</button>
               ))}
             </div>
             <div className="mt-5 space-y-3">

--- a/app/business/[id]/contact/page.tsx
+++ b/app/business/[id]/contact/page.tsx
@@ -18,8 +18,8 @@ export default function ContactPage() {
   useEffect(() => { fetch(`/api/businesses/${id}`).then((r) => r.json()).then(setBiz).catch(() => {}); }, [id]);
   const name = biz?.name || "this business";
 
-  const field = "w-full rounded-[10px] border bg-white px-3.5 py-2.5 t-body outline-none";
-  const fieldStyle = { borderColor: "var(--card-edge)", color: "var(--ink-900)" } as const;
+  const field = "man-field w-full px-3.5 py-2.5 t-body";
+  const fieldStyle = { color: "var(--ink-900)" } as const;
 
   return (
     <div style={{ background: "var(--paper)" }} className="px-6 py-8 md:px-14">

--- a/app/business/[id]/page.tsx
+++ b/app/business/[id]/page.tsx
@@ -269,7 +269,7 @@ export default function BusinessDetailPage() {
                     {rv.title && <div className="mt-2 t-label-sm" style={{ color: "var(--ink-900)" }}>{rv.title}</div>}
                     <p className="mt-1.5 t-body-sm" style={{ color: "var(--ink-700)", lineHeight: 1.6 }}>{rv.content || rv.text}</p>
                     {rv.ownerResponse && (
-                      <div className="mt-3 rounded-[10px] p-3.5" style={{ background: "var(--paper-2)" }}>
+                      <div className="mt-3 rounded-[8px] p-3.5" style={{ background: "var(--paper-2)" }}>
                         <div className="flex items-center gap-1.5 t-eyebrow" style={{ color: "var(--ink-500)" }}><Seal size={13} /> Response from {business.name}</div>
                         <p className="mt-1.5 t-body-sm" style={{ color: "var(--ink-700)" }}>{rv.ownerResponse}</p>
                       </div>

--- a/app/business/[id]/page.tsx
+++ b/app/business/[id]/page.tsx
@@ -132,12 +132,12 @@ export default function BusinessDetailPage() {
           ))}
         </div>
         <div className="absolute inset-x-0 top-0 flex items-center justify-between px-5 py-4 md:px-8">
-          <Link href="/search" className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 t-body-sm shadow-sm" style={{ background: "rgba(255,255,255,0.95)", color: "var(--ink-900)" }}><ArrowLeft size={15} /> Back</Link>
+          <Link href="/search" className="man-focus inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 t-body-sm shadow-sm" style={{ background: "rgba(255,255,255,0.95)", color: "var(--ink-900)" }}><ArrowLeft size={15} /> Back</Link>
           <div className="flex gap-2">
-            <button onClick={toggleFav} className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 t-body-sm shadow-sm" style={{ background: "rgba(255,255,255,0.95)", color: "var(--ink-900)" }}>
+            <button onClick={toggleFav} className="man-focus inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 t-body-sm shadow-sm" style={{ background: "rgba(255,255,255,0.95)", color: "var(--ink-900)" }}>
               <Heart size={15} fill={fav ? "var(--clay-500)" : "none"} stroke={fav ? "var(--clay-500)" : "currentColor"} /> {fav ? "Saved" : "Save"}
             </button>
-            <button onClick={share} className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 t-body-sm shadow-sm" style={{ background: "rgba(255,255,255,0.95)", color: "var(--ink-900)" }}>
+            <button onClick={share} className="man-focus inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 t-body-sm shadow-sm" style={{ background: "rgba(255,255,255,0.95)", color: "var(--ink-900)" }}>
               <Share2 size={15} /> {copied ? "Copied!" : "Share"}
             </button>
           </div>

--- a/app/business/[id]/page.tsx
+++ b/app/business/[id]/page.tsx
@@ -132,12 +132,12 @@ export default function BusinessDetailPage() {
           ))}
         </div>
         <div className="absolute inset-x-0 top-0 flex items-center justify-between px-5 py-4 md:px-8">
-          <Link href="/search" className="man-focus inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 t-body-sm shadow-sm" style={{ background: "rgba(255,255,255,0.95)", color: "var(--ink-900)" }}><ArrowLeft size={15} /> Back</Link>
+          <Link href="/search" className="man-focus inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 t-body-sm shadow-[var(--shadow-soft)]" style={{ background: "rgba(255,255,255,0.95)", color: "var(--ink-900)" }}><ArrowLeft size={15} /> Back</Link>
           <div className="flex gap-2">
-            <button onClick={toggleFav} className="man-focus inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 t-body-sm shadow-sm" style={{ background: "rgba(255,255,255,0.95)", color: "var(--ink-900)" }}>
+            <button onClick={toggleFav} className="man-focus inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 t-body-sm shadow-[var(--shadow-soft)]" style={{ background: "rgba(255,255,255,0.95)", color: "var(--ink-900)" }}>
               <Heart size={15} fill={fav ? "var(--clay-500)" : "none"} stroke={fav ? "var(--clay-500)" : "currentColor"} /> {fav ? "Saved" : "Save"}
             </button>
-            <button onClick={share} className="man-focus inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 t-body-sm shadow-sm" style={{ background: "rgba(255,255,255,0.95)", color: "var(--ink-900)" }}>
+            <button onClick={share} className="man-focus inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 t-body-sm shadow-[var(--shadow-soft)]" style={{ background: "rgba(255,255,255,0.95)", color: "var(--ink-900)" }}>
               <Share2 size={15} /> {copied ? "Copied!" : "Share"}
             </button>
           </div>

--- a/app/business/[id]/page.tsx
+++ b/app/business/[id]/page.tsx
@@ -184,14 +184,14 @@ export default function BusinessDetailPage() {
         <div className="grid gap-6 pb-10 lg:grid-cols-[1.7fr_1fr]">
           <div className="min-w-0 grid gap-4 content-start">
             {/* About */}
-            <ManCard style={{ padding: 22 }}>
+            <ManCard style={{ padding: 20 }}>
               <div className="t-h4" style={{ color: "var(--ink-900)" }}>About {business.name}</div>
               <p className="mt-2 t-body" style={{ color: "var(--ink-700)", lineHeight: 1.6 }}>{business.description}</p>
             </ManCard>
 
             {/* Highlights */}
             {amenities.length > 0 && (
-              <ManCard style={{ padding: 22 }}>
+              <ManCard style={{ padding: 20 }}>
                 <div className="t-h4" style={{ color: "var(--ink-900)", marginBottom: 12 }}>What This Place Offers</div>
                 <div className="grid gap-2.5 sm:grid-cols-2">
                   {amenities.map((a) => (
@@ -206,7 +206,7 @@ export default function BusinessDetailPage() {
 
             {/* Halal & trust */}
             {verified && (
-              <ManCard style={{ padding: 22, background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
+              <ManCard style={{ padding: 20, background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
                 <div className="flex items-start gap-3.5">
                   <Seal size={30} />
                   <div className="flex-1">
@@ -221,7 +221,7 @@ export default function BusinessDetailPage() {
             )}
 
             {/* Reviews summary */}
-            <ManCard id="reviews" style={{ padding: 22 }}>
+            <ManCard id="reviews" style={{ padding: 20 }}>
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="t-h4" style={{ color: "var(--ink-900)" }}>{business.reviewCount > 0 ? `${business.reviewCount} Reviews` : "Reviews"}</div>
                 <Link href={`/business/${id}/review`}><Button size="sm"><Pencil className="mr-1.5 h-4 w-4" /> Write a Review</Button></Link>
@@ -282,7 +282,7 @@ export default function BusinessDetailPage() {
 
           {/* Sticky aside */}
           <aside className="grid h-fit gap-4 lg:sticky lg:top-[88px]">
-            <ManCard style={{ padding: 22 }}>
+            <ManCard style={{ padding: 20 }}>
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2 t-h4" style={{ color: "var(--ink-900)" }}><Clock size={16} style={{ color: "var(--moss-700)" }} /> Hours</div>
                 <span className="rounded-full px-2 py-0.5 t-body-xs" style={{ fontWeight: 600, background: status.open ? "var(--moss-50)" : "var(--paper-2)", color: status.open ? "var(--moss-700)" : "var(--ink-500)" }}>{status.open ? "Open" : "Closed"}</span>
@@ -301,7 +301,7 @@ export default function BusinessDetailPage() {
               </div>
             </ManCard>
 
-            <ManCard style={{ padding: 22 }}>
+            <ManCard style={{ padding: 20 }}>
               <div className="t-h4" style={{ color: "var(--ink-900)" }}>Contact & Location</div>
               <div className="mt-3 grid gap-3 t-body-sm">
                 <div className="flex items-start gap-2.5"><MapPin size={15} style={{ color: "var(--ink-400)", marginTop: 2 }} /><span style={{ color: "var(--ink-700)" }}>{business.address}<br />{business.city}, {business.state} {business.zipCode}</span></div>

--- a/app/business/[id]/review/page.tsx
+++ b/app/business/[id]/review/page.tsx
@@ -28,10 +28,10 @@ export default function WriteReviewPage() {
         <Link href={`/business/${id}`} className="t-body-sm inline-flex items-center gap-1" style={{ color: "var(--ink-500)" }}>
           <ArrowLeft size={14} /> Back to {name}
         </Link>
-        <h1 className="t-h2" style={{ color: "var(--ink-900)", marginTop: 14 }}>Review {name}</h1>
+        <h1 className="t-h2" style={{ color: "var(--ink-900)", marginTop: 12 }}>Review {name}</h1>
 
         {published ? (
-          <ManCard style={{ padding: 40, marginTop: 18, textAlign: "center" }}>
+          <ManCard style={{ padding: 40, marginTop: 16, textAlign: "center" }}>
             <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full" style={{ background: "var(--moss-50)" }}>
               <CheckCircle2 size={30} style={{ color: "var(--moss-700)" }} />
             </div>
@@ -43,7 +43,7 @@ export default function WriteReviewPage() {
             </div>
           </ManCard>
         ) : (
-        <ManCard style={{ padding: 26, marginTop: 18 }}>
+        <ManCard style={{ padding: 24, marginTop: 16 }}>
           <div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>Your rating</div>
           <div className="mt-2 flex gap-1">
             {[1, 2, 3, 4, 5].map((n) => (
@@ -55,11 +55,11 @@ export default function WriteReviewPage() {
 
           <div className="mt-5 grid gap-3 sm:grid-cols-2">
             <div>
-              <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 6 }}>Visit date</div>
+              <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 4 }}>Visit date</div>
               <DatePicker placeholder="Select visit date" />
             </div>
             <div>
-              <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 6 }}>Visit type</div>
+              <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 4 }}>Visit type</div>
               <Select defaultValue="Dine-in" options={["Dine-in", "Takeout", "Delivery", "Catering"].map((s) => ({ value: s, label: s }))} />
             </div>
           </div>
@@ -68,7 +68,7 @@ export default function WriteReviewPage() {
           </div>
 
           <div className="mt-5">
-            <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 6 }}>Your review</div>
+            <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 4 }}>Your review</div>
             <textarea value={text} onChange={(e) => setText(e.target.value.slice(0, 1000))} placeholder="Share the details — food, service, halal experience…"
               className="w-full rounded-[8px] border bg-white px-3.5 py-2.5 t-body outline-none" style={{ borderColor: "var(--card-edge)", color: "var(--ink-900)", minHeight: 120, resize: "vertical" }} />
             <div className="mt-1 text-right t-body-xs" style={{ color: "var(--ink-400)" }}>{text.length}/1000</div>

--- a/app/business/[id]/review/page.tsx
+++ b/app/business/[id]/review/page.tsx
@@ -91,7 +91,7 @@ export default function WriteReviewPage() {
             <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 8 }}>Photos</div>
             <div className="flex gap-2">
               {[0, 1, 2].map((i) => (
-                <button key={i} className="flex h-20 w-20 items-center justify-center rounded-[10px]" style={{ border: "2px dashed var(--card-edge)", color: "var(--ink-400)" }}><Plus size={18} /></button>
+                <button key={i} className="man-focus flex h-20 w-20 items-center justify-center rounded-[10px]" style={{ border: "2px dashed var(--card-edge)", color: "var(--ink-400)" }}><Plus size={18} /></button>
               ))}
             </div>
           </div>

--- a/app/business/[id]/review/page.tsx
+++ b/app/business/[id]/review/page.tsx
@@ -70,7 +70,7 @@ export default function WriteReviewPage() {
           <div className="mt-5">
             <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 6 }}>Your review</div>
             <textarea value={text} onChange={(e) => setText(e.target.value.slice(0, 1000))} placeholder="Share the details — food, service, halal experience…"
-              className="w-full rounded-[10px] border bg-white px-3.5 py-2.5 t-body outline-none" style={{ borderColor: "var(--card-edge)", color: "var(--ink-900)", minHeight: 120, resize: "vertical" }} />
+              className="w-full rounded-[8px] border bg-white px-3.5 py-2.5 t-body outline-none" style={{ borderColor: "var(--card-edge)", color: "var(--ink-900)", minHeight: 120, resize: "vertical" }} />
             <div className="mt-1 text-right t-body-xs" style={{ color: "var(--ink-400)" }}>{text.length}/1000</div>
           </div>
 
@@ -91,7 +91,7 @@ export default function WriteReviewPage() {
             <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 8 }}>Photos</div>
             <div className="flex gap-2">
               {[0, 1, 2].map((i) => (
-                <button key={i} className="man-focus flex h-20 w-20 items-center justify-center rounded-[10px]" style={{ border: "2px dashed var(--card-edge)", color: "var(--ink-400)" }}><Plus size={18} /></button>
+                <button key={i} className="man-focus flex h-20 w-20 items-center justify-center rounded-[8px]" style={{ border: "2px dashed var(--card-edge)", color: "var(--ink-400)" }}><Plus size={18} /></button>
               ))}
             </div>
           </div>

--- a/app/business/[id]/review/page.tsx
+++ b/app/business/[id]/review/page.tsx
@@ -80,7 +80,7 @@ export default function WriteReviewPage() {
               {halalTags.map((t) => {
                 const on = tags.includes(t);
                 return (
-                  <button key={t} onClick={() => toggle(t)} className="t-body-sm rounded-full px-3 py-1.5"
+                  <button key={t} onClick={() => toggle(t)} className="man-focus t-body-sm rounded-full px-3 py-1.5"
                     style={on ? { background: "var(--moss-700)", color: "var(--bone)" } : { background: "var(--paper-2)", color: "var(--ink-700)" }}>{t}</button>
                 );
               })}

--- a/app/claim-business/page.tsx
+++ b/app/claim-business/page.tsx
@@ -51,7 +51,7 @@ export default function ClaimBusinessPage() {
 
         <ManCard style={{ padding: 22, marginTop: 18 }}>
           <form onSubmit={runSearch} className="flex flex-col gap-2.5 sm:flex-row">
-            <div className="man-field-wrap flex flex-1 items-center gap-2 rounded-[10px] border bg-white px-3.5">
+            <div className="man-field-wrap flex flex-1 items-center gap-2 rounded-[8px] border bg-white px-3.5">
               <Search size={18} style={{ color: "var(--ink-400)" }} />
               <input value={query} onChange={(e) => setQuery(e.target.value)} className="w-full bg-transparent py-2.5 t-body outline-none" style={{ color: "var(--ink-900)" }} placeholder="Search your business name…" />
             </div>

--- a/app/claim-business/page.tsx
+++ b/app/claim-business/page.tsx
@@ -18,7 +18,6 @@ const CITIES = [
   "Davis, CA",
 ].map((c) => ({ value: c, label: c }));
 
-const fs = { borderColor: "var(--card-edge)" } as const;
 
 export default function ClaimBusinessPage() {
   const [query, setQuery] = useState("");
@@ -52,7 +51,7 @@ export default function ClaimBusinessPage() {
 
         <ManCard style={{ padding: 22, marginTop: 18 }}>
           <form onSubmit={runSearch} className="flex flex-col gap-2.5 sm:flex-row">
-            <div className="flex flex-1 items-center gap-2 rounded-[10px] border bg-white px-3.5" style={fs}>
+            <div className="man-field-wrap flex flex-1 items-center gap-2 rounded-[10px] border bg-white px-3.5">
               <Search size={18} style={{ color: "var(--ink-400)" }} />
               <input value={query} onChange={(e) => setQuery(e.target.value)} className="w-full bg-transparent py-2.5 t-body outline-none" style={{ color: "var(--ink-900)" }} placeholder="Search your business name…" />
             </div>

--- a/app/claim-business/page.tsx
+++ b/app/claim-business/page.tsx
@@ -46,10 +46,10 @@ export default function ClaimBusinessPage() {
     <div style={{ background: "var(--paper)" }} className="px-6 py-8 md:px-14">
       <div className="mx-auto max-w-[900px]">
         <Link href="/for-business" className="t-body-sm inline-flex items-center gap-1" style={{ color: "var(--ink-500)" }}><ArrowLeft size={14} /> Back</Link>
-        <h1 className="t-h2" style={{ color: "var(--ink-900)", marginTop: 14 }}>Claim Your Business</h1>
-        <p className="t-body" style={{ color: "var(--ink-500)", marginTop: 6 }}>Search for your business to claim it — we&apos;ll guide you through proving ownership next.</p>
+        <h1 className="t-h2" style={{ color: "var(--ink-900)", marginTop: 12 }}>Claim Your Business</h1>
+        <p className="t-body" style={{ color: "var(--ink-500)", marginTop: 4 }}>Search for your business to claim it — we&apos;ll guide you through proving ownership next.</p>
 
-        <ManCard style={{ padding: 22, marginTop: 18 }}>
+        <ManCard style={{ padding: 20, marginTop: 16 }}>
           <form onSubmit={runSearch} className="flex flex-col gap-2.5 sm:flex-row">
             <div className="man-field-wrap flex flex-1 items-center gap-2 rounded-[8px] border bg-white px-3.5">
               <Search size={18} style={{ color: "var(--ink-400)" }} />
@@ -71,7 +71,7 @@ export default function ClaimBusinessPage() {
               </div>
               <div className="mt-3 grid gap-3">
                 {matches.map((b, i) => (
-                  <ManCard key={b.id} style={{ padding: 14, border: i === 0 ? "1.5px solid var(--moss-700)" : "1px solid var(--card-edge)" }} className="flex items-center gap-4">
+                  <ManCard key={b.id} style={{ padding: 16, border: i === 0 ? "1.5px solid var(--moss-700)" : "1px solid var(--card-edge)" }} className="flex items-center gap-4">
                     <Photo src={b.coverImage} seed={b.name} w={80} h={60} radius={8} />
                     <div className="flex-1">
                       <div className="flex items-center gap-2">
@@ -100,7 +100,7 @@ export default function ClaimBusinessPage() {
 
         {/* Add new — offered once a search has run */}
         {searched && !loading && (
-          <ManCard style={{ padding: 18, marginTop: 16, background: "var(--paper-2)" }} className="flex items-center justify-between gap-4">
+          <ManCard style={{ padding: 20, marginTop: 16, background: "var(--paper-2)" }} className="flex items-center justify-between gap-4">
             <div>
               <div className="t-label" style={{ color: "var(--ink-900)" }}>Don&apos;t see your business?</div>
               <div className="t-body-sm" style={{ color: "var(--ink-500)" }}>Add it from scratch — we&apos;ll route it through verification.</div>

--- a/app/dashboard/deals/page.tsx
+++ b/app/dashboard/deals/page.tsx
@@ -15,7 +15,7 @@ const promos = [
 ];
 
 export default function PromotionsPage() {
-  const field = "w-full rounded-[10px] border bg-white px-3.5 py-2.5 t-body outline-none";
+  const field = "w-full rounded-[8px] border bg-white px-3.5 py-2.5 t-body outline-none";
   const fs = { borderColor: "var(--card-edge)", color: "var(--ink-900)" } as const;
   return (
     <OwnerShell active="promos">

--- a/app/dashboard/deals/page.tsx
+++ b/app/dashboard/deals/page.tsx
@@ -48,7 +48,7 @@ export default function PromotionsPage() {
             </div>
           </div>
 
-          <ManCard style={{ padding: 22 }}>
+          <ManCard style={{ padding: 20 }}>
             <div className="t-h4" style={{ color: "var(--ink-900)" }}>Quick Promotion</div>
             <div className="mt-3.5 grid gap-3">
               <input className={field} style={fs} placeholder="Title (e.g. Friday iftar special)" />

--- a/app/dashboard/leads/page.tsx
+++ b/app/dashboard/leads/page.tsx
@@ -34,7 +34,7 @@ export default function LeadsPage() {
           {/* Conversation list */}
           <div className="flex w-[320px] flex-shrink-0 flex-col" style={{ borderRight: "1px solid var(--card-edge)" }}>
             <div className="flex h-[69px] items-center px-4" style={{ borderBottom: "1px solid var(--card-edge)" }}>
-              <div className="flex w-full items-center gap-2 rounded-[10px] border px-3 py-2" style={{ borderColor: "var(--card-edge)", background: "#ffffff" }}>
+              <div className="man-field-wrap flex w-full items-center gap-2 rounded-[10px] border px-3 py-2" style={{ background: "#ffffff" }}>
                 <Search size={15} style={{ color: "var(--ink-400)" }} /><input placeholder="Search leads" className="w-full bg-transparent t-body-sm outline-none" style={{ color: "var(--ink-900)" }} />
               </div>
             </div>
@@ -81,7 +81,7 @@ export default function LeadsPage() {
                 {QUICK.map((q) => <button key={q} onClick={() => setDraft(q)} className="t-body-xs rounded-full px-2.5 py-1" style={{ background: "var(--paper-2)", color: "var(--ink-700)" }}>{q}</button>)}
               </div>
               <div className="flex items-end gap-2">
-                <textarea value={draft} onChange={(e) => setDraft(e.target.value)} placeholder="Write a reply…" className="flex-1 rounded-[12px] border bg-white px-3.5 py-2.5 t-body-sm outline-none" style={{ borderColor: "var(--card-edge)", color: "var(--ink-900)", minHeight: 44, resize: "none" }} />
+                <textarea value={draft} onChange={(e) => setDraft(e.target.value)} placeholder="Write a reply…" className="man-field flex-1 px-3.5 py-2.5 t-body-sm" style={{ color: "var(--ink-900)", minHeight: 44, resize: "none" }} />
                 <Button size="sm"><Send className="h-4 w-4" /></Button>
               </div>
             </div>

--- a/app/dashboard/leads/page.tsx
+++ b/app/dashboard/leads/page.tsx
@@ -78,7 +78,7 @@ export default function LeadsPage() {
             <div className="px-6 py-4" style={{ borderTop: "1px solid var(--card-edge)", background: "#ffffff" }}>
               <div className="mb-2 flex flex-wrap items-center gap-2">
                 <span className="inline-flex items-center gap-1 t-body-xs" style={{ color: "var(--moss-700)" }}><Sparkles size={12} /> Quick replies</span>
-                {QUICK.map((q) => <button key={q} onClick={() => setDraft(q)} className="t-body-xs rounded-full px-2.5 py-1" style={{ background: "var(--paper-2)", color: "var(--ink-700)" }}>{q}</button>)}
+                {QUICK.map((q) => <button key={q} onClick={() => setDraft(q)} className="man-focus t-body-xs rounded-full px-2.5 py-1" style={{ background: "var(--paper-2)", color: "var(--ink-700)" }}>{q}</button>)}
               </div>
               <div className="flex items-end gap-2">
                 <textarea value={draft} onChange={(e) => setDraft(e.target.value)} placeholder="Write a reply…" className="man-field flex-1 px-3.5 py-2.5 t-body-sm" style={{ color: "var(--ink-900)", minHeight: 44, resize: "none" }} />

--- a/app/dashboard/leads/page.tsx
+++ b/app/dashboard/leads/page.tsx
@@ -34,7 +34,7 @@ export default function LeadsPage() {
           {/* Conversation list */}
           <div className="flex w-[320px] flex-shrink-0 flex-col" style={{ borderRight: "1px solid var(--card-edge)" }}>
             <div className="flex h-[69px] items-center px-4" style={{ borderBottom: "1px solid var(--card-edge)" }}>
-              <div className="man-field-wrap flex w-full items-center gap-2 rounded-[10px] border px-3 py-2" style={{ background: "#ffffff" }}>
+              <div className="man-field-wrap flex w-full items-center gap-2 rounded-[8px] border px-3 py-2" style={{ background: "#ffffff" }}>
                 <Search size={15} style={{ color: "var(--ink-400)" }} /><input placeholder="Search leads" className="w-full bg-transparent t-body-sm outline-none" style={{ color: "var(--ink-900)" }} />
               </div>
             </div>
@@ -66,7 +66,7 @@ export default function LeadsPage() {
             <div className="flex-1 space-y-3 overflow-auto px-6 py-5">
               {active.thread.map((m, i) => (
                 <div key={i} className={`flex ${m.me ? "justify-end" : "justify-start"}`}>
-                  <div className="max-w-[70%] rounded-[14px] px-3.5 py-2.5" style={m.me ? { background: "var(--moss-700)", color: "var(--bone)" } : { background: "#ffffff", border: "1px solid var(--card-edge)", color: "var(--ink-900)" }}>
+                  <div className="max-w-[70%] rounded-[12px] px-3.5 py-2.5" style={m.me ? { background: "var(--moss-700)", color: "var(--bone)" } : { background: "#ffffff", border: "1px solid var(--card-edge)", color: "var(--ink-900)" }}>
                     <div className="t-body">{m.t}</div>
                     <div className="t-body-xs mt-1" style={{ color: m.me ? "rgba(255,255,255,0.7)" : "var(--ink-400)" }}>{m.time}</div>
                   </div>

--- a/app/dashboard/leads/page.tsx
+++ b/app/dashboard/leads/page.tsx
@@ -30,7 +30,7 @@ export default function LeadsPage() {
         <h1 className="t-h3" style={{ color: "var(--ink-900)" }}>Lead Inbox</h1>
         <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 4 }}>Messages from people who found you on Manaakhah</p>
 
-        <ManCard style={{ padding: 0, overflow: "hidden", marginTop: 18 }} className="flex h-[calc(100vh-200px)] min-h-[480px]">
+        <ManCard style={{ padding: 0, overflow: "hidden", marginTop: 16 }} className="flex h-[calc(100vh-200px)] min-h-[480px]">
           {/* Conversation list */}
           <div className="flex w-[320px] flex-shrink-0 flex-col" style={{ borderRight: "1px solid var(--card-edge)" }}>
             <div className="flex h-[69px] items-center px-4" style={{ borderBottom: "1px solid var(--card-edge)" }}>

--- a/app/dashboard/listing/page.tsx
+++ b/app/dashboard/listing/page.tsx
@@ -13,8 +13,8 @@ const selOpts = (...l: string[]) => l.map((s) => ({ value: s, label: s }));
 
 const TABS = ["Overview", "Photos", "Menu", "Halal details", "Hours", "Amenities"];
 const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-const fieldCls = "w-full rounded-[10px] border bg-white px-3.5 py-2.5 t-body outline-none";
-const fs = { borderColor: "var(--card-edge)", color: "var(--ink-900)" } as const;
+const fieldCls = "man-field w-full px-3.5 py-2.5 t-body";
+const fs = { color: "var(--ink-900)" } as const;
 const completeness = [
   ["Business basics", true], ["Address & hours", true], ["Cover photo", true],
   ["5+ gallery photos", true], ["Menu uploaded", false], ["Halal certificate", true], ["Amenities tagged", false],
@@ -113,9 +113,9 @@ export default function ListingProfilePage() {
                   {DAYS.map((d, i) => (
                     <div key={d} className="flex items-center gap-3">
                       <span className="t-body-sm" style={{ color: "var(--ink-700)", width: 44 }}>{d}</span>
-                      <input className="rounded-[8px] border bg-white px-2.5 py-1.5 t-body-sm outline-none" style={fs} defaultValue="11:00" disabled={i === 6} />
+                      <input className="man-field px-2.5 py-1.5 t-body-sm" style={fs} defaultValue="11:00" disabled={i === 6} />
                       <span className="t-body-sm" style={{ color: "var(--ink-400)" }}>–</span>
-                      <input className="rounded-[8px] border bg-white px-2.5 py-1.5 t-body-sm outline-none" style={fs} defaultValue="22:00" disabled={i === 6} />
+                      <input className="man-field px-2.5 py-1.5 t-body-sm" style={fs} defaultValue="22:00" disabled={i === 6} />
                       <Checkbox className="ml-auto" defaultChecked={i === 6} label="Closed" />
                     </div>
                   ))}

--- a/app/dashboard/listing/page.tsx
+++ b/app/dashboard/listing/page.tsx
@@ -39,7 +39,7 @@ export default function ListingProfilePage() {
         {/* Tabs */}
         <div className="mb-5 flex flex-wrap gap-2 border-b" style={{ borderColor: "var(--card-edge)" }}>
           {TABS.map((t) => (
-            <button key={t} onClick={() => setTab(t)} className="man-focus rounded-[6px] t-body-sm -mb-px border-b-2 px-1 pb-2.5"
+            <button key={t} onClick={() => setTab(t)} className="man-focus rounded-[4px] t-body-sm -mb-px border-b-2 px-1 pb-2.5"
               style={tab === t ? { borderColor: "var(--moss-700)", color: "var(--ink-900)", fontWeight: 600 } : { borderColor: "transparent", color: "var(--ink-500)" }}>{t}</button>
           ))}
         </div>
@@ -70,9 +70,9 @@ export default function ListingProfilePage() {
                 <div className="t-h4" style={{ color: "var(--ink-900)", marginBottom: 12 }}>Gallery</div>
                 <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
                   {["sac-famous-kabob", "kabob-1", "kabob-2", "kabob-3", "kabob-4"].map((s) => (
-                    <Photo key={s} seed={s} h={120} radius={10} />
+                    <Photo key={s} seed={s} h={120} radius={8} />
                   ))}
-                  <button className="man-focus flex h-[120px] flex-col items-center justify-center gap-1.5 rounded-[10px] border-2 border-dashed t-body-xs" style={{ borderColor: "var(--card-edge)", color: "var(--ink-500)" }}><Plus size={20} /> Add photo</button>
+                  <button className="man-focus flex h-[120px] flex-col items-center justify-center gap-1.5 rounded-[8px] border-2 border-dashed t-body-xs" style={{ borderColor: "var(--card-edge)", color: "var(--ink-500)" }}><Plus size={20} /> Add photo</button>
                 </div>
               </ManCard>
             )}
@@ -82,7 +82,7 @@ export default function ListingProfilePage() {
                 <div className="flex items-center justify-between"><div className="t-h4" style={{ color: "var(--ink-900)" }}>Menu</div><Button size="sm"><Plus className="mr-1.5 h-4 w-4" /> Add Item</Button></div>
                 <div className="mt-4 grid gap-2.5">
                   {[["Chicken kabob plate", "$14.99"], ["Lamb chops", "$24.99"], ["Beef koobideh", "$15.99"], ["Mixed grill", "$22.99"]].map(([n, p]) => (
-                    <div key={n} className="flex items-center justify-between rounded-[10px] border px-3.5 py-2.5" style={{ borderColor: "var(--card-edge)" }}>
+                    <div key={n} className="flex items-center justify-between rounded-[8px] border px-3.5 py-2.5" style={{ borderColor: "var(--card-edge)" }}>
                       <span className="t-body-sm" style={{ color: "var(--ink-900)" }}>{n}</span>
                       <span className="t-body-sm" style={{ color: "var(--ink-500)" }}>{p}</span>
                     </div>
@@ -93,14 +93,14 @@ export default function ListingProfilePage() {
 
             {tab === "Halal details" && (
               <ManCard style={{ padding: 24 }}>
-                <div className="flex items-start gap-3 rounded-[10px] p-3.5" style={{ background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
+                <div className="flex items-start gap-3 rounded-[8px] p-3.5" style={{ background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
                   <Seal size={24} />
                   <div className="flex-1"><div className="t-label" style={{ color: "var(--ink-900)" }}>Verified halal · HFSAA active</div><div className="t-body-sm" style={{ color: "var(--ink-700)", marginTop: 2 }}>Certificate expires March 14, 2027.</div></div>
                   <Link href="/business/sac-famous-kabob/certification"><Button variant="outline" size="sm">Manage</Button></Link>
                 </div>
                 <div className="mt-4 grid gap-2 sm:grid-cols-2">
                   {[["All meat is zabihah", true], ["Separate halal kitchen", true], ["No alcohol served", true], ["Vegetarian options", true], ["Vegan options", false]].map(([o, on]) => (
-                    <div key={o as string} className="flex items-center rounded-[10px] border px-3 py-2.5" style={{ borderColor: "var(--card-edge)" }}><Checkbox defaultChecked={on as boolean} label={o} /></div>
+                    <div key={o as string} className="flex items-center rounded-[8px] border px-3 py-2.5" style={{ borderColor: "var(--card-edge)" }}><Checkbox defaultChecked={on as boolean} label={o} /></div>
                   ))}
                 </div>
               </ManCard>
@@ -128,7 +128,7 @@ export default function ListingProfilePage() {
                 <div className="t-h4" style={{ color: "var(--ink-900)", marginBottom: 12 }}>Amenities</div>
                 <div className="grid gap-2 sm:grid-cols-2">
                   {[["Prayer space", true], ["Family seating", true], ["Parking", true], ["Wheelchair access", true], ["Outdoor seating", false], ["Catering", true], ["Delivery", true], ["Wi-Fi", false]].map(([o, on]) => (
-                    <div key={o as string} className="flex items-center rounded-[10px] border px-3 py-2.5" style={{ borderColor: "var(--card-edge)" }}><Checkbox defaultChecked={on as boolean} label={o} /></div>
+                    <div key={o as string} className="flex items-center rounded-[8px] border px-3 py-2.5" style={{ borderColor: "var(--card-edge)" }}><Checkbox defaultChecked={on as boolean} label={o} /></div>
                   ))}
                 </div>
               </ManCard>

--- a/app/dashboard/listing/page.tsx
+++ b/app/dashboard/listing/page.tsx
@@ -21,7 +21,7 @@ const completeness = [
 ] as const;
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
-  return <div><div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 5 }}>{label}</div>{children}</div>;
+  return <div><div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 4 }}>{label}</div>{children}</div>;
 }
 
 export default function ListingProfilePage() {
@@ -139,7 +139,7 @@ export default function ListingProfilePage() {
 
           {/* Completeness column */}
           <div className="grid gap-3.5">
-            <ManCard style={{ padding: 22 }}>
+            <ManCard style={{ padding: 20 }}>
               <div className="flex items-baseline justify-between"><div className="t-h4" style={{ color: "var(--ink-900)" }}>Profile Completeness</div><span className="t-h3" style={{ color: "var(--moss-700)" }}>{pct}%</span></div>
               <div className="mt-3 h-2.5 w-full rounded-full" style={{ background: "var(--paper-2)" }}><div className="h-2.5 rounded-full" style={{ width: `${pct}%`, background: "var(--moss-700)" }} /></div>
               <div className="mt-4 grid gap-2.5">
@@ -150,10 +150,10 @@ export default function ListingProfilePage() {
                   </div>
                 ))}
               </div>
-              <p className="t-body-xs" style={{ color: "var(--ink-500)", marginTop: 14 }}>Complete profiles get up to 3× more profile views.</p>
+              <p className="t-body-xs" style={{ color: "var(--ink-500)", marginTop: 12 }}>Complete profiles get up to 3× more profile views.</p>
             </ManCard>
 
-            <ManCard style={{ padding: 22, background: "var(--clay-50)", border: "1px solid var(--clay-100)" }}>
+            <ManCard style={{ padding: 20, background: "var(--clay-50)", border: "1px solid var(--clay-100)" }}>
               <Tag tone="clay">Tip</Tag>
               <div className="t-label" style={{ color: "var(--ink-900)", marginTop: 8 }}>Add your menu</div>
               <p className="t-body-sm" style={{ color: "var(--ink-700)", marginTop: 4 }}>Listings with a menu convert 40% more enquiries. Upload yours under the Menu tab.</p>

--- a/app/dashboard/listing/page.tsx
+++ b/app/dashboard/listing/page.tsx
@@ -39,7 +39,7 @@ export default function ListingProfilePage() {
         {/* Tabs */}
         <div className="mb-5 flex flex-wrap gap-2 border-b" style={{ borderColor: "var(--card-edge)" }}>
           {TABS.map((t) => (
-            <button key={t} onClick={() => setTab(t)} className="t-body-sm -mb-px border-b-2 px-1 pb-2.5"
+            <button key={t} onClick={() => setTab(t)} className="man-focus t-body-sm -mb-px border-b-2 px-1 pb-2.5"
               style={tab === t ? { borderColor: "var(--moss-700)", color: "var(--ink-900)", fontWeight: 600 } : { borderColor: "transparent", color: "var(--ink-500)" }}>{t}</button>
           ))}
         </div>
@@ -72,7 +72,7 @@ export default function ListingProfilePage() {
                   {["sac-famous-kabob", "kabob-1", "kabob-2", "kabob-3", "kabob-4"].map((s) => (
                     <Photo key={s} seed={s} h={120} radius={10} />
                   ))}
-                  <button className="flex h-[120px] flex-col items-center justify-center gap-1.5 rounded-[10px] border-2 border-dashed t-body-xs" style={{ borderColor: "var(--card-edge)", color: "var(--ink-500)" }}><Plus size={20} /> Add photo</button>
+                  <button className="man-focus flex h-[120px] flex-col items-center justify-center gap-1.5 rounded-[10px] border-2 border-dashed t-body-xs" style={{ borderColor: "var(--card-edge)", color: "var(--ink-500)" }}><Plus size={20} /> Add photo</button>
                 </div>
               </ManCard>
             )}

--- a/app/dashboard/listing/page.tsx
+++ b/app/dashboard/listing/page.tsx
@@ -39,7 +39,7 @@ export default function ListingProfilePage() {
         {/* Tabs */}
         <div className="mb-5 flex flex-wrap gap-2 border-b" style={{ borderColor: "var(--card-edge)" }}>
           {TABS.map((t) => (
-            <button key={t} onClick={() => setTab(t)} className="man-focus t-body-sm -mb-px border-b-2 px-1 pb-2.5"
+            <button key={t} onClick={() => setTab(t)} className="man-focus rounded-[6px] t-body-sm -mb-px border-b-2 px-1 pb-2.5"
               style={tab === t ? { borderColor: "var(--moss-700)", color: "var(--ink-900)", fontWeight: 600 } : { borderColor: "transparent", color: "var(--ink-500)" }}>{t}</button>
           ))}
         </div>

--- a/app/dashboard/new-listing/page.tsx
+++ b/app/dashboard/new-listing/page.tsx
@@ -19,7 +19,7 @@ const fs = { color: "var(--ink-900)" } as const;
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div>
-      <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 5 }}>{label}</div>
+      <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 4 }}>{label}</div>
       {children}
     </div>
   );

--- a/app/dashboard/new-listing/page.tsx
+++ b/app/dashboard/new-listing/page.tsx
@@ -13,8 +13,8 @@ import { ArrowLeft, ArrowRight, Check, Plus, MapPin, Clock, Image as ImageIcon, 
 
 const STEPS = ["Basics", "Address & hours", "Halal details", "Photos", "Review"];
 const DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
-const fieldCls = "w-full rounded-[10px] border bg-white px-3.5 py-2.5 t-body outline-none";
-const fs = { borderColor: "var(--card-edge)", color: "var(--ink-900)" } as const;
+const fieldCls = "man-field w-full px-3.5 py-2.5 t-body";
+const fs = { color: "var(--ink-900)" } as const;
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (

--- a/app/dashboard/new-listing/page.tsx
+++ b/app/dashboard/new-listing/page.tsx
@@ -39,7 +39,7 @@ export default function NewListingPage() {
         <div className="mb-6 flex items-center gap-1.5">
           {STEPS.map((s, i) => (
             <div key={s} className="flex flex-1 items-center gap-1.5">
-              <button onClick={() => setStep(i)} className="man-focus rounded-[10px] flex items-center gap-2">
+              <button onClick={() => setStep(i)} className="man-focus rounded-[8px] flex items-center gap-2">
                 <span className="flex h-6 w-6 items-center justify-center rounded-full t-body-xs" style={i < step ? { background: "var(--moss-700)", color: "var(--bone)" } : i === step ? { background: "var(--ink-900)", color: "var(--bone)" } : { background: "var(--paper-2)", color: "var(--ink-400)", border: "1px solid var(--card-edge)" }}>
                   {i < step ? <Check size={12} /> : i + 1}
                 </span>
@@ -96,11 +96,11 @@ export default function NewListingPage() {
               <Field label="What&apos;s halal here?">
                 <div className="grid gap-2 sm:grid-cols-2">
                   {["All meat is zabihah", "Separate halal kitchen", "No alcohol served", "Vegetarian options"].map((o) => (
-                    <div key={o} className="flex items-center rounded-[10px] border px-3 py-2.5" style={{ borderColor: "var(--card-edge)" }}><Checkbox defaultChecked label={o} /></div>
+                    <div key={o} className="flex items-center rounded-[8px] border px-3 py-2.5" style={{ borderColor: "var(--card-edge)" }}><Checkbox defaultChecked label={o} /></div>
                   ))}
                 </div>
               </Field>
-              <div className="flex items-start gap-3 rounded-[10px] p-3.5" style={{ background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
+              <div className="flex items-start gap-3 rounded-[8px] p-3.5" style={{ background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
                 <Seal size={22} />
                 <p className="t-body-sm" style={{ color: "var(--ink-700)" }}>Upload your certificate on the next step. Our verification team cross-checks it with the issuing body before your Seal goes live.</p>
               </div>
@@ -117,7 +117,7 @@ export default function NewListingPage() {
                 ))}
               </div>
               <Field label="Halal certificate (PDF or image)">
-                <button className="man-focus flex w-full items-center justify-center gap-2 rounded-[10px] border-2 border-dashed py-5 t-body-sm" style={{ borderColor: "var(--card-edge)", color: "var(--ink-500)" }}><Plus size={16} /> Upload certificate</button>
+                <button className="man-focus flex w-full items-center justify-center gap-2 rounded-[8px] border-2 border-dashed py-5 t-body-sm" style={{ borderColor: "var(--card-edge)", color: "var(--ink-500)" }}><Plus size={16} /> Upload certificate</button>
               </Field>
             </div>
           )}

--- a/app/dashboard/new-listing/page.tsx
+++ b/app/dashboard/new-listing/page.tsx
@@ -39,7 +39,7 @@ export default function NewListingPage() {
         <div className="mb-6 flex items-center gap-1.5">
           {STEPS.map((s, i) => (
             <div key={s} className="flex flex-1 items-center gap-1.5">
-              <button onClick={() => setStep(i)} className="man-focus flex items-center gap-2">
+              <button onClick={() => setStep(i)} className="man-focus rounded-[10px] flex items-center gap-2">
                 <span className="flex h-6 w-6 items-center justify-center rounded-full t-body-xs" style={i < step ? { background: "var(--moss-700)", color: "var(--bone)" } : i === step ? { background: "var(--ink-900)", color: "var(--bone)" } : { background: "var(--paper-2)", color: "var(--ink-400)", border: "1px solid var(--card-edge)" }}>
                   {i < step ? <Check size={12} /> : i + 1}
                 </span>

--- a/app/dashboard/new-listing/page.tsx
+++ b/app/dashboard/new-listing/page.tsx
@@ -39,7 +39,7 @@ export default function NewListingPage() {
         <div className="mb-6 flex items-center gap-1.5">
           {STEPS.map((s, i) => (
             <div key={s} className="flex flex-1 items-center gap-1.5">
-              <button onClick={() => setStep(i)} className="flex items-center gap-2">
+              <button onClick={() => setStep(i)} className="man-focus flex items-center gap-2">
                 <span className="flex h-6 w-6 items-center justify-center rounded-full t-body-xs" style={i < step ? { background: "var(--moss-700)", color: "var(--bone)" } : i === step ? { background: "var(--ink-900)", color: "var(--bone)" } : { background: "var(--paper-2)", color: "var(--ink-400)", border: "1px solid var(--card-edge)" }}>
                   {i < step ? <Check size={12} /> : i + 1}
                 </span>
@@ -111,13 +111,13 @@ export default function NewListingPage() {
             <div className="grid gap-4">
               <div className="flex items-center gap-2 t-h4" style={{ color: "var(--ink-900)" }}><ImageIcon size={18} style={{ color: "var(--moss-700)" }} /> Photos & documents</div>
               <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-                <button className="flex aspect-square flex-col items-center justify-center gap-1.5 rounded-[12px] border-2 border-dashed t-body-xs" style={{ borderColor: "var(--card-edge)", color: "var(--ink-500)" }}><Plus size={20} /> Cover photo</button>
+                <button className="man-focus flex aspect-square flex-col items-center justify-center gap-1.5 rounded-[12px] border-2 border-dashed t-body-xs" style={{ borderColor: "var(--card-edge)", color: "var(--ink-500)" }}><Plus size={20} /> Cover photo</button>
                 {[1, 2, 3].map((i) => (
-                  <button key={i} className="flex aspect-square flex-col items-center justify-center gap-1.5 rounded-[12px] border-2 border-dashed t-body-xs" style={{ borderColor: "var(--card-edge)", color: "var(--ink-500)" }}><Plus size={20} /> Add photo</button>
+                  <button key={i} className="man-focus flex aspect-square flex-col items-center justify-center gap-1.5 rounded-[12px] border-2 border-dashed t-body-xs" style={{ borderColor: "var(--card-edge)", color: "var(--ink-500)" }}><Plus size={20} /> Add photo</button>
                 ))}
               </div>
               <Field label="Halal certificate (PDF or image)">
-                <button className="flex w-full items-center justify-center gap-2 rounded-[10px] border-2 border-dashed py-5 t-body-sm" style={{ borderColor: "var(--card-edge)", color: "var(--ink-500)" }}><Plus size={16} /> Upload certificate</button>
+                <button className="man-focus flex w-full items-center justify-center gap-2 rounded-[10px] border-2 border-dashed py-5 t-body-sm" style={{ borderColor: "var(--card-edge)", color: "var(--ink-500)" }}><Plus size={16} /> Upload certificate</button>
               </Field>
             </div>
           )}

--- a/app/dashboard/notifications/page.tsx
+++ b/app/dashboard/notifications/page.tsx
@@ -34,8 +34,8 @@ export default function OwnerNotificationsPage() {
 
         <div className="mb-5 flex flex-wrap gap-2">
           {FILTERS.map((f) => (
-            <button key={f} onClick={() => setFilter(f)} className="t-body-sm rounded-full px-3 py-1.5"
-              style={filter === f ? { background: "var(--ink-900)", color: "var(--bone)" } : { background: "var(--card)", border: "1px solid var(--card-edge)", color: "var(--ink-700)" }}>{f}</button>
+            <button key={f} onClick={() => setFilter(f)} className="man-focus t-body-sm rounded-full px-3 py-1.5"
+              style={filter === f ? { background: "var(--moss-700)", color: "var(--bone)" } : { background: "var(--card)", border: "1px solid var(--card-edge)", color: "var(--ink-700)" }}>{f}</button>
           ))}
         </div>
 

--- a/app/dashboard/onboarding/page.tsx
+++ b/app/dashboard/onboarding/page.tsx
@@ -23,9 +23,9 @@ export default function OnboardingPage() {
       <div className="mx-auto max-w-[720px]">
         <div className="flex items-center gap-2"><Seal size={22} /><Tag tone="moss">Ownership Verified</Tag></div>
         <h1 className="t-h2" style={{ color: "var(--ink-900)", marginTop: 12 }}>Welcome to Manaakhah, Famous Kabob</h1>
-        <p className="t-body" style={{ color: "var(--ink-500)", marginTop: 6 }}>Finish these steps to get the most out of your listing. You can always come back later.</p>
+        <p className="t-body" style={{ color: "var(--ink-500)", marginTop: 4 }}>Finish these steps to get the most out of your listing. You can always come back later.</p>
 
-        <ManCard style={{ padding: 22, marginTop: 22 }}>
+        <ManCard style={{ padding: 20, marginTop: 20 }}>
           <div className="flex items-baseline justify-between">
             <div className="t-h4" style={{ color: "var(--ink-900)" }}>Setup Progress</div>
             <span className="t-h3" style={{ color: "var(--moss-700)" }}>{done}/{STEPS.length}</span>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -65,7 +65,7 @@ export default function DashboardPage() {
           {([["overview", "Overview"], ["analytics", "Analytics"]] as const).map(([k, l]) => {
             const on = tab === k;
             return (
-              <button key={k} onClick={() => setTab(k)} className="man-focus rounded-[6px] px-4 py-2.5 t-label transition-colors"
+              <button key={k} onClick={() => setTab(k)} className="man-focus rounded-[4px] px-4 py-2.5 t-label transition-colors"
                 style={{ color: on ? "var(--ink-900)" : "var(--ink-500)", borderBottom: on ? "2px solid var(--moss-700)" : "2px solid transparent", marginBottom: -1 }}>
                 {l}
               </button>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -65,7 +65,7 @@ export default function DashboardPage() {
           {([["overview", "Overview"], ["analytics", "Analytics"]] as const).map(([k, l]) => {
             const on = tab === k;
             return (
-              <button key={k} onClick={() => setTab(k)} className="man-focus px-4 py-2.5 t-label transition-colors"
+              <button key={k} onClick={() => setTab(k)} className="man-focus rounded-[6px] px-4 py-2.5 t-label transition-colors"
                 style={{ color: on ? "var(--ink-900)" : "var(--ink-500)", borderBottom: on ? "2px solid var(--moss-700)" : "2px solid transparent", marginBottom: -1 }}>
                 {l}
               </button>
@@ -149,7 +149,7 @@ export default function DashboardPage() {
             <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
               <p className="t-body-sm" style={{ color: "var(--ink-500)" }}>How people discover and engage with your listing</p>
               <div className="flex gap-2">
-                <button className="flex items-center gap-2 rounded-[8px] border bg-white px-3 py-2 t-body-sm" style={{ borderColor: "var(--card-edge)", color: "var(--ink-700)" }}><Calendar size={15} /> Last 30 days</button>
+                <button className="man-focus flex items-center gap-2 rounded-[12px] border bg-white px-3 py-2 t-body-sm" style={{ borderColor: "var(--card-edge)", color: "var(--ink-700)" }}><Calendar size={15} /> Last 30 days</button>
                 <Button variant="outline" size="sm"><Download className="mr-1.5 h-4 w-4" /> Export</Button>
               </div>
             </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -149,7 +149,7 @@ export default function DashboardPage() {
             <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
               <p className="t-body-sm" style={{ color: "var(--ink-500)" }}>How people discover and engage with your listing</p>
               <div className="flex gap-2">
-                <button className="man-focus flex items-center gap-2 rounded-[12px] border bg-white px-3 py-2 t-body-sm" style={{ borderColor: "var(--card-edge)", color: "var(--ink-700)" }}><Calendar size={15} /> Last 30 days</button>
+                <button className="man-focus flex items-center gap-2 rounded-[8px] border bg-white px-3 py-2 t-body-sm" style={{ borderColor: "var(--card-edge)", color: "var(--ink-700)" }}><Calendar size={15} /> Last 30 days</button>
                 <Button variant="outline" size="sm"><Download className="mr-1.5 h-4 w-4" /> Export</Button>
               </div>
             </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -76,7 +76,7 @@ export default function DashboardPage() {
         {tab === "overview" ? (
           <div className="mt-5">
             {/* Verification banner */}
-            <ManCard style={{ padding: 18, background: "var(--moss-50)", border: "1px solid var(--moss-200)" }} className="flex flex-wrap items-center gap-4">
+            <ManCard style={{ padding: 20, background: "var(--moss-50)", border: "1px solid var(--moss-200)" }} className="flex flex-wrap items-center gap-4">
               <Seal size={28} />
               <div className="flex-1">
                 <div className="t-label" style={{ color: "var(--ink-900)" }}>Verified halal · HFSAA active</div>
@@ -95,7 +95,7 @@ export default function DashboardPage() {
 
             {/* Things to do + leads + reviews */}
             <div className="mt-4 grid gap-3.5 lg:grid-cols-3">
-              <ManCard style={{ padding: 22 }}>
+              <ManCard style={{ padding: 20 }}>
                 <div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>For your attention</div>
                 <div className="t-h4" style={{ color: "var(--ink-900)", marginTop: 4 }}>3 Things to Do</div>
                 <div className="mt-3.5 grid gap-3">
@@ -112,7 +112,7 @@ export default function DashboardPage() {
                 </div>
               </ManCard>
 
-              <ManCard style={{ padding: 22 }}>
+              <ManCard style={{ padding: 20 }}>
                 <div className="flex items-baseline justify-between">
                   <div className="t-h4" style={{ color: "var(--ink-900)" }}>Recent Enquiries</div>
                   <Link href="/dashboard/leads" className="t-body-sm" style={{ color: "var(--moss-700)" }}>View inbox →</Link>
@@ -128,7 +128,7 @@ export default function DashboardPage() {
                 </div>
               </ManCard>
 
-              <ManCard style={{ padding: 22 }}>
+              <ManCard style={{ padding: 20 }}>
                 <div className="flex items-baseline justify-between">
                   <div className="t-h4" style={{ color: "var(--ink-900)" }}>Latest Reviews</div>
                   <Link href="/dashboard/reviews" className="t-body-sm" style={{ color: "var(--moss-700)" }}>Respond →</Link>
@@ -164,7 +164,7 @@ export default function DashboardPage() {
 
             <div className="mt-4 grid gap-3.5 lg:grid-cols-[1.4fr_1fr]">
               {/* Funnel */}
-              <ManCard style={{ padding: 22 }}>
+              <ManCard style={{ padding: 20 }}>
                 <div className="t-h4" style={{ color: "var(--ink-900)" }}>Discovery Funnel</div>
                 <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 2 }}>From appearing in search to a visit</p>
                 <div className="mt-4 grid gap-3">
@@ -180,7 +180,7 @@ export default function DashboardPage() {
               </ManCard>
 
               {/* Sources */}
-              <ManCard style={{ padding: 22 }}>
+              <ManCard style={{ padding: 20 }}>
                 <div className="t-h4" style={{ color: "var(--ink-900)" }}>Where People Find You</div>
                 <div className="mt-4 grid gap-3">
                   {sources.map((s) => (
@@ -196,7 +196,7 @@ export default function DashboardPage() {
             </div>
 
             {/* Daily traffic bars */}
-            <ManCard style={{ padding: 22, marginTop: 14 }}>
+            <ManCard style={{ padding: 20, marginTop: 12 }}>
               <div className="t-h4" style={{ color: "var(--ink-900)" }}>Daily Traffic</div>
               <div className="mt-4 flex items-end gap-3" style={{ height: 140 }}>
                 {days.map((d, i) => (

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -65,7 +65,7 @@ export default function DashboardPage() {
           {([["overview", "Overview"], ["analytics", "Analytics"]] as const).map(([k, l]) => {
             const on = tab === k;
             return (
-              <button key={k} onClick={() => setTab(k)} className="px-4 py-2.5 t-label transition-colors"
+              <button key={k} onClick={() => setTab(k)} className="man-focus px-4 py-2.5 t-label transition-colors"
                 style={{ color: on ? "var(--ink-900)" : "var(--ink-500)", borderBottom: on ? "2px solid var(--moss-700)" : "2px solid transparent", marginBottom: -1 }}>
                 {l}
               </button>

--- a/app/dashboard/reviews/page.tsx
+++ b/app/dashboard/reviews/page.tsx
@@ -60,7 +60,7 @@ export default function ReviewsPage() {
               <p className="t-body" style={{ color: "var(--ink-700)", marginTop: 8 }}>Great kabobs and the prayer space was a real plus for our family. Service was a touch slow on a busy Friday.</p>
               <div className="mt-2 flex flex-wrap gap-1.5"><Tag tone="moss">Prayer Space</Tag><Tag tone="moss">Family Seating</Tag></div>
 
-              <div className="mt-4 rounded-[10px] p-3.5" style={{ background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
+              <div className="mt-4 rounded-[8px] p-3.5" style={{ background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
                 <div className="flex items-center gap-1.5 t-eyebrow" style={{ color: "var(--moss-700)" }}><Sparkles size={13} /> AI-suggested reply</div>
                 <textarea value={draft} onChange={(e) => setDraft(e.target.value)} className="mt-2 w-full bg-transparent t-body outline-none" style={{ color: "var(--ink-900)", minHeight: 70, resize: "vertical" }} />
                 <div className="mt-2 flex justify-end gap-2">
@@ -83,7 +83,7 @@ export default function ReviewsPage() {
               </div>
               <div className="mt-1"><Stars n={5} /></div>
               <p className="t-body" style={{ color: "var(--ink-700)", marginTop: 8 }}>Best mixed grill in Sacramento. Certification gave me total peace of mind.</p>
-              <div className="mt-3 rounded-[10px] p-3.5" style={{ background: "var(--paper-2)" }}>
+              <div className="mt-3 rounded-[8px] p-3.5" style={{ background: "var(--paper-2)" }}>
                 <div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>Your reply</div>
                 <p className="t-body-sm" style={{ color: "var(--ink-700)", marginTop: 4 }}>Thank you so much, Mariam! It means a lot that the certification matters to you — see you next time!</p>
               </div>

--- a/app/dashboard/reviews/page.tsx
+++ b/app/dashboard/reviews/page.tsx
@@ -23,7 +23,7 @@ export default function ReviewsPage() {
         <PH title="Reviews & Responses" sub="Respond fast — replied businesses convert 2× better" />
 
         <div className="grid gap-3.5 lg:grid-cols-[1.4fr_1fr_1fr_1fr]">
-          <ManCard style={{ padding: 18 }}>
+          <ManCard style={{ padding: 20 }}>
             <div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>Rating distribution</div>
             <div className="mt-3 grid gap-1.5">
               {dist.map(([s, p]) => (
@@ -48,7 +48,7 @@ export default function ReviewsPage() {
         </div>
 
         {/* Awaiting response — AI suggested reply */}
-        <ManCard style={{ padding: 22, marginBottom: 14 }}>
+        <ManCard style={{ padding: 20, marginBottom: 12 }}>
           <div className="flex items-start gap-3">
             <Avatar name="Hassan K" size={40} />
             <div className="flex-1">
@@ -73,7 +73,7 @@ export default function ReviewsPage() {
         </ManCard>
 
         {/* Replied */}
-        <ManCard style={{ padding: 22 }}>
+        <ManCard style={{ padding: 20 }}>
           <div className="flex items-start gap-3">
             <Avatar name="Mariam T" size={40} />
             <div className="flex-1">

--- a/app/dashboard/reviews/page.tsx
+++ b/app/dashboard/reviews/page.tsx
@@ -42,8 +42,8 @@ export default function ReviewsPage() {
 
         <div className="my-5 flex flex-wrap gap-2">
           {filters.map((f) => (
-            <button key={f} onClick={() => setFilter(f)} className="t-body-sm rounded-full px-3 py-1.5"
-              style={filter === f ? { background: "var(--ink-900)", color: "var(--bone)" } : { background: "var(--card)", border: "1px solid var(--card-edge)", color: "var(--ink-700)" }}>{f}</button>
+            <button key={f} onClick={() => setFilter(f)} className="man-focus t-body-sm rounded-full px-3 py-1.5"
+              style={filter === f ? { background: "var(--moss-700)", color: "var(--bone)" } : { background: "var(--card)", border: "1px solid var(--card-edge)", color: "var(--ink-700)" }}>{f}</button>
           ))}
         </div>
 

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -7,8 +7,8 @@ import { Select } from "@/components/man/Select";
 import { Button } from "@/components/ui/button";
 import { Plus, AlertTriangle } from "lucide-react";
 
-const fieldCls = "w-full rounded-[10px] border bg-white px-3.5 py-2.5 t-body outline-none";
-const fs = { borderColor: "var(--card-edge)", color: "var(--ink-900)" } as const;
+const fieldCls = "man-field w-full px-3.5 py-2.5 t-body";
+const fs = { color: "var(--ink-900)" } as const;
 const TEAM = [
   { n: "Yusuf A.", email: "yusuf@famouskabob.com", role: "Owner" },
   { n: "Mariam A.", email: "mariam@famouskabob.com", role: "Manager" },

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -27,7 +27,7 @@ function Toggle({ on, set, label, sub }: { on: boolean; set: (v: boolean) => voi
 }
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
-  return <div><div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 5 }}>{label}</div>{children}</div>;
+  return <div><div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 4 }}>{label}</div>{children}</div>;
 }
 
 export default function BusinessSettingsPage() {
@@ -53,7 +53,7 @@ export default function BusinessSettingsPage() {
 
           {/* Business details */}
           <ManCard style={{ padding: 24 }}>
-            <div className="t-h4" style={{ color: "var(--ink-900)", marginBottom: 14 }}>Business Account</div>
+            <div className="t-h4" style={{ color: "var(--ink-900)", marginBottom: 12 }}>Business Account</div>
             <div className="grid gap-4 sm:grid-cols-2">
               <Field label="Legal business name"><input className={fieldCls} style={fs} defaultValue="Famous Kabob LLC" /></Field>
               <Field label="EIN / tax ID"><input className={fieldCls} style={fs} defaultValue="••-•••4821" /></Field>

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -75,7 +75,7 @@ export default function BusinessSettingsPage() {
                   <Avatar name={m.n} size={34} />
                   <div className="flex-1"><div className="t-label-sm" style={{ color: "var(--ink-900)" }}>{m.n}</div><div className="t-body-xs" style={{ color: "var(--ink-500)" }}>{m.email}</div></div>
                   <Tag tone={m.role === "Owner" ? "moss" : "default"}>{m.role}</Tag>
-                  {m.role !== "Owner" && <button className="t-body-sm" style={{ color: "var(--ink-500)" }}>Remove</button>}
+                  {m.role !== "Owner" && <button className="man-focus rounded-[6px] t-body-sm" style={{ color: "var(--ink-500)" }}>Remove</button>}
                 </div>
               ))}
             </div>

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -71,11 +71,11 @@ export default function BusinessSettingsPage() {
             <div className="flex items-center justify-between"><div className="t-h4" style={{ color: "var(--ink-900)" }}>Team & Access</div><Button size="sm"><Plus className="mr-1.5 h-4 w-4" /> Invite</Button></div>
             <div className="mt-3.5 grid gap-2">
               {TEAM.map((m) => (
-                <div key={m.email} className="flex items-center gap-3 rounded-[10px] border px-3.5 py-2.5" style={{ borderColor: "var(--card-edge)" }}>
+                <div key={m.email} className="flex items-center gap-3 rounded-[8px] border px-3.5 py-2.5" style={{ borderColor: "var(--card-edge)" }}>
                   <Avatar name={m.n} size={34} />
                   <div className="flex-1"><div className="t-label-sm" style={{ color: "var(--ink-900)" }}>{m.n}</div><div className="t-body-xs" style={{ color: "var(--ink-500)" }}>{m.email}</div></div>
                   <Tag tone={m.role === "Owner" ? "moss" : "default"}>{m.role}</Tag>
-                  {m.role !== "Owner" && <button className="man-focus rounded-[6px] t-body-sm" style={{ color: "var(--ink-500)" }}>Remove</button>}
+                  {m.role !== "Owner" && <button className="man-focus rounded-[4px] t-body-sm" style={{ color: "var(--ink-500)" }}>Remove</button>}
                 </div>
               ))}
             </div>

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -19,7 +19,7 @@ function Toggle({ on, set, label, sub }: { on: boolean; set: (v: boolean) => voi
   return (
     <div className="flex items-center justify-between py-2.5">
       <div className="pr-4"><div className="t-label-sm" style={{ color: "var(--ink-900)" }}>{label}</div><div className="t-body-xs" style={{ color: "var(--ink-500)", marginTop: 1 }}>{sub}</div></div>
-      <button onClick={() => set(!on)} className="relative h-6 w-11 flex-shrink-0 rounded-full transition-colors" style={{ background: on ? "var(--moss-700)" : "var(--card-edge)" }}>
+      <button onClick={() => set(!on)} className="man-focus relative h-6 w-11 flex-shrink-0 rounded-full transition-colors" style={{ background: on ? "var(--moss-700)" : "var(--card-edge)" }}>
         <span className="absolute top-0.5 h-5 w-5 rounded-full bg-white transition-all" style={{ left: on ? 22 : 2 }} />
       </button>
     </div>

--- a/app/dashboard/subscription/page.tsx
+++ b/app/dashboard/subscription/page.tsx
@@ -45,8 +45,8 @@ export default function SubscriptionPage() {
           {/* Upgrade */}
           <div className="rounded-[12px] p-6" style={{ background: "var(--clay-50)", border: "1px solid var(--clay-100)" }}>
             <Tag tone="clay">Premier</Tag>
-            <div className="t-h3" style={{ color: "var(--ink-900)", marginTop: 10 }}>Go Top of Search</div>
-            <p className="t-body-sm" style={{ color: "var(--ink-700)", marginTop: 6 }}>Featured placement, AI review replies, multi-location, and a direct line to our verification team.</p>
+            <div className="t-h3" style={{ color: "var(--ink-900)", marginTop: 8 }}>Go Top of Search</div>
+            <p className="t-body-sm" style={{ color: "var(--ink-700)", marginTop: 4 }}>Featured placement, AI review replies, multi-location, and a direct line to our verification team.</p>
             <div className="mt-3 t-h2" style={{ color: "var(--ink-900)" }}>$99<span className="t-body" style={{ color: "var(--ink-500)" }}>/mo</span></div>
             <Button className="mt-3">Upgrade to Premier</Button>
           </div>
@@ -54,7 +54,7 @@ export default function SubscriptionPage() {
 
         <div className="mt-5 grid gap-3.5 lg:grid-cols-[1fr_1.4fr]">
           {/* Payment method */}
-          <ManCard style={{ padding: 22 }}>
+          <ManCard style={{ padding: 20 }}>
             <div className="t-h4" style={{ color: "var(--ink-900)" }}>Payment Method</div>
             <div className="mt-3 flex items-center gap-3 rounded-[8px] p-3" style={{ background: "var(--paper-2)" }}>
               <CreditCard size={22} style={{ color: "var(--ink-700)" }} />

--- a/app/dashboard/subscription/page.tsx
+++ b/app/dashboard/subscription/page.tsx
@@ -73,7 +73,7 @@ export default function SubscriptionPage() {
                 <div className="flex-1"><div className="t-label-sm" style={{ color: "var(--ink-900)" }}>{d}</div><div className="t-body-xs" style={{ color: "var(--ink-500)" }}>{p}</div></div>
                 <span className="t-body-sm" style={{ color: "var(--ink-900)" }}>{a}</span>
                 <Tag tone="ok">Paid</Tag>
-                <button className="rounded-lg p-1.5 hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-500)" }}><Download size={16} /></button>
+                <button className="man-focus rounded-lg p-1.5 hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-500)" }}><Download size={16} /></button>
               </div>
             ))}
           </ManCard>

--- a/app/dashboard/subscription/page.tsx
+++ b/app/dashboard/subscription/page.tsx
@@ -43,7 +43,7 @@ export default function SubscriptionPage() {
           </ManCard>
 
           {/* Upgrade */}
-          <div className="rounded-[14px] p-6" style={{ background: "var(--clay-50)", border: "1px solid var(--clay-100)" }}>
+          <div className="rounded-[12px] p-6" style={{ background: "var(--clay-50)", border: "1px solid var(--clay-100)" }}>
             <Tag tone="clay">Premier</Tag>
             <div className="t-h3" style={{ color: "var(--ink-900)", marginTop: 10 }}>Go Top of Search</div>
             <p className="t-body-sm" style={{ color: "var(--ink-700)", marginTop: 6 }}>Featured placement, AI review replies, multi-location, and a direct line to our verification team.</p>
@@ -56,7 +56,7 @@ export default function SubscriptionPage() {
           {/* Payment method */}
           <ManCard style={{ padding: 22 }}>
             <div className="t-h4" style={{ color: "var(--ink-900)" }}>Payment Method</div>
-            <div className="mt-3 flex items-center gap-3 rounded-[10px] p-3" style={{ background: "var(--paper-2)" }}>
+            <div className="mt-3 flex items-center gap-3 rounded-[8px] p-3" style={{ background: "var(--paper-2)" }}>
               <CreditCard size={22} style={{ color: "var(--ink-700)" }} />
               <div className="flex-1"><div className="t-label" style={{ color: "var(--ink-900)" }}>Visa ending 4242</div><div className="t-body-xs" style={{ color: "var(--ink-500)" }}>Expires 08/28</div></div>
               <Button variant="outline" size="sm">Update</Button>

--- a/app/dashboard/verification/page.tsx
+++ b/app/dashboard/verification/page.tsx
@@ -39,7 +39,7 @@ export default function VerificationPage() {
               {METHODS.map((m) => {
                 const on = method === m.k;
                 return (
-                  <button key={m.k} onClick={() => setMethod(m.k)} className="flex items-start gap-3.5 rounded-[14px] p-4 text-left transition-colors" style={{ background: "#ffffff", border: on ? "1.5px solid var(--moss-700)" : "1px solid var(--card-edge)" }}>
+                  <button key={m.k} onClick={() => setMethod(m.k)} className="man-focus flex items-start gap-3.5 rounded-[14px] p-4 text-left transition-colors" style={{ background: "#ffffff", border: on ? "1.5px solid var(--moss-700)" : "1px solid var(--card-edge)" }}>
                     <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full" style={{ background: on ? "var(--moss-50)" : "var(--paper-2)" }}><m.Icon size={18} style={{ color: on ? "var(--moss-700)" : "var(--ink-500)" }} /></span>
                     <div className="flex-1">
                       <div className="flex items-center justify-between">

--- a/app/dashboard/verification/page.tsx
+++ b/app/dashboard/verification/page.tsx
@@ -23,7 +23,7 @@ export default function VerificationPage() {
         <PH title="Verify Ownership" sub="One quick check confirms you represent this business" />
 
         {/* Business being claimed */}
-        <ManCard style={{ padding: 14, marginBottom: 18 }} className="flex items-center gap-4">
+        <ManCard style={{ padding: 16, marginBottom: 16 }} className="flex items-center gap-4">
           <Photo seed="sac-famous-kabob" w={72} h={56} radius={8} />
           <div className="flex-1">
             <div className="flex items-center gap-2"><Seal size={16} /><div className="t-label" style={{ color: "var(--ink-900)" }}>Famous Kabob</div></div>
@@ -34,7 +34,7 @@ export default function VerificationPage() {
 
         {!sent ? (
           <>
-            <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 10 }}>Choose how to verify</div>
+            <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 8 }}>Choose how to verify</div>
             <div className="grid gap-3">
               {METHODS.map((m) => {
                 const on = method === m.k;

--- a/app/dashboard/verification/page.tsx
+++ b/app/dashboard/verification/page.tsx
@@ -39,7 +39,7 @@ export default function VerificationPage() {
               {METHODS.map((m) => {
                 const on = method === m.k;
                 return (
-                  <button key={m.k} onClick={() => setMethod(m.k)} className="man-focus flex items-start gap-3.5 rounded-[14px] p-4 text-left transition-colors" style={{ background: "#ffffff", border: on ? "1.5px solid var(--moss-700)" : "1px solid var(--card-edge)" }}>
+                  <button key={m.k} onClick={() => setMethod(m.k)} className="man-focus flex items-start gap-3.5 rounded-[12px] p-4 text-left transition-colors" style={{ background: "#ffffff", border: on ? "1.5px solid var(--moss-700)" : "1px solid var(--card-edge)" }}>
                     <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full" style={{ background: on ? "var(--moss-50)" : "var(--paper-2)" }}><m.Icon size={18} style={{ color: on ? "var(--moss-700)" : "var(--ink-500)" }} /></span>
                     <div className="flex-1">
                       <div className="flex items-center justify-between">
@@ -60,7 +60,7 @@ export default function VerificationPage() {
           </>
         ) : (
           <ManCard style={{ padding: 28 }}>
-            <div className="flex items-start gap-3 rounded-[10px] p-3.5" style={{ background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
+            <div className="flex items-start gap-3 rounded-[8px] p-3.5" style={{ background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
               <Seal size={24} />
               <div><div className="t-label" style={{ color: "var(--ink-900)" }}>Verification on its way</div><div className="t-body-sm" style={{ color: "var(--ink-700)", marginTop: 2 }}>{method === "phone" ? "We're calling (916) 483-1700 now — enter the 6-digit code you hear." : method === "email" ? "Check owner@famouskabob.com for a verification link." : "Our team will review your document within 1 business day."}</div></div>
             </div>

--- a/app/dashboard/verification/page.tsx
+++ b/app/dashboard/verification/page.tsx
@@ -67,7 +67,7 @@ export default function VerificationPage() {
             {method === "phone" && (
               <div className="mt-5">
                 <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 8 }}>Enter code</div>
-                <div className="flex gap-2">{[0, 1, 2, 3, 4, 5].map((i) => <input key={i} maxLength={1} className="h-12 w-12 rounded-[10px] border bg-white text-center t-h4 outline-none" style={{ borderColor: "var(--card-edge)", color: "var(--ink-900)" }} />)}</div>
+                <div className="flex gap-2">{[0, 1, 2, 3, 4, 5].map((i) => <input key={i} maxLength={1} className="man-field h-12 w-12 text-center t-h4" style={{ color: "var(--ink-900)" }} />)}</div>
               </div>
             )}
             <div className="mt-6 flex items-center justify-between">

--- a/app/for-business/page.tsx
+++ b/app/for-business/page.tsx
@@ -19,8 +19,8 @@ export default function ForBusinessPage() {
     <div style={{ background: "var(--paper)" }}>
       <section className="mx-auto max-w-[820px] px-6 py-16 text-center">
         <Tag tone="clay">For Owners</Tag>
-        <h1 className="t-h1" style={{ color: "var(--ink-900)", marginTop: 14, fontSize: 48 }}>Get Found, Get Verified, Grow.</h1>
-        <p className="t-body-lg" style={{ color: "var(--ink-500)", margin: "14px auto 0", maxWidth: 580 }}>
+        <h1 className="t-h1" style={{ color: "var(--ink-900)", marginTop: 12, fontSize: 48 }}>Get Found, Get Verified, Grow.</h1>
+        <p className="t-body-lg" style={{ color: "var(--ink-500)", margin: "12px auto 0", maxWidth: 580 }}>
           Claim your listing in 3 minutes. Verify in 7 days. Reach the Sacramento community actively searching for Muslim-owned businesses.
         </p>
         <div className="mt-6 flex justify-center gap-2.5">
@@ -34,13 +34,13 @@ export default function ForBusinessPage() {
         <PH title="Two Ways to Get Listed" sub="Claim an existing listing, or add your business from scratch. Both end with verified status." />
         <div className="grid gap-4 md:grid-cols-2">
           {/* Claim */}
-          <ManCard style={{ padding: 26 }}>
+          <ManCard style={{ padding: 24 }}>
             <Tag tone="moss">Most Owners</Tag>
             <div className="t-h3" style={{ color: "var(--ink-900)", marginTop: 12 }}>Claim an Existing Listing</div>
-            <p className="t-body" style={{ color: "var(--ink-500)", marginTop: 6 }}>
+            <p className="t-body" style={{ color: "var(--ink-500)", marginTop: 4 }}>
               We&apos;ve already indexed 110+ Sacramento businesses. Search yours, prove ownership, and take over the listing.
             </p>
-            <div style={{ marginTop: 16, padding: 14, background: "var(--paper-2)", borderRadius: 8 }}>
+            <div style={{ marginTop: 16, padding: 16, background: "var(--paper-2)", borderRadius: 8 }}>
               <div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>What you&apos;ll need</div>
               <div className="mt-2 grid gap-1.5">
                 {claimNeeds.map((t) => (
@@ -53,13 +53,13 @@ export default function ForBusinessPage() {
           </ManCard>
 
           {/* Add new */}
-          <ManCard style={{ padding: 26 }}>
+          <ManCard style={{ padding: 24 }}>
             <Tag>Not Yet Listed</Tag>
             <div className="t-h3" style={{ color: "var(--ink-900)", marginTop: 12 }}>Add a New Business</div>
-            <p className="t-body" style={{ color: "var(--ink-500)", marginTop: 6 }}>
+            <p className="t-body" style={{ color: "var(--ink-500)", marginTop: 4 }}>
               Brand new, recently moved, or just not on Manaakhah yet? Create the listing and we&apos;ll route it through verification.
             </p>
-            <div style={{ marginTop: 16, padding: 14, background: "var(--paper-2)", borderRadius: 8 }}>
+            <div style={{ marginTop: 16, padding: 16, background: "var(--paper-2)", borderRadius: 8 }}>
               <div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>What you&apos;ll need</div>
               <div className="mt-2 grid gap-1.5">
                 {addNeeds.map((t) => (
@@ -78,7 +78,7 @@ export default function ForBusinessPage() {
         {props.map(({ Icon, t, d }) => (
           <ManCard key={t} style={{ padding: 20 }}>
             <Icon size={20} style={{ color: "var(--moss-700)" }} />
-            <div className="t-h4" style={{ color: "var(--ink-900)", marginTop: 10 }}>{t}</div>
+            <div className="t-h4" style={{ color: "var(--ink-900)", marginTop: 8 }}>{t}</div>
             <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 4 }}>{d}</p>
           </ManCard>
         ))}

--- a/app/for-business/page.tsx
+++ b/app/for-business/page.tsx
@@ -40,7 +40,7 @@ export default function ForBusinessPage() {
             <p className="t-body" style={{ color: "var(--ink-500)", marginTop: 6 }}>
               We&apos;ve already indexed 110+ Sacramento businesses. Search yours, prove ownership, and take over the listing.
             </p>
-            <div style={{ marginTop: 16, padding: 14, background: "var(--paper-2)", borderRadius: 10 }}>
+            <div style={{ marginTop: 16, padding: 14, background: "var(--paper-2)", borderRadius: 8 }}>
               <div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>What you&apos;ll need</div>
               <div className="mt-2 grid gap-1.5">
                 {claimNeeds.map((t) => (
@@ -59,7 +59,7 @@ export default function ForBusinessPage() {
             <p className="t-body" style={{ color: "var(--ink-500)", marginTop: 6 }}>
               Brand new, recently moved, or just not on Manaakhah yet? Create the listing and we&apos;ll route it through verification.
             </p>
-            <div style={{ marginTop: 16, padding: 14, background: "var(--paper-2)", borderRadius: 10 }}>
+            <div style={{ marginTop: 16, padding: 14, background: "var(--paper-2)", borderRadius: 8 }}>
               <div className="t-eyebrow" style={{ color: "var(--ink-500)" }}>What you&apos;ll need</div>
               <div className="mt-2 grid gap-1.5">
                 {addNeeds.map((t) => (

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -40,7 +40,7 @@ export default function ForgotPasswordPage() {
         <p className="mt-2 t-body" style={{ color: "var(--ink-500)" }}>
           If an account exists with this email, we&apos;ve sent a password reset link. It expires in 1 hour.
         </p>
-        <div className="mt-5 flex items-start gap-2 rounded-[10px] p-3 t-body-sm" style={{ background: "var(--clay-50)", color: "var(--clay-700)" }}>
+        <div className="mt-5 flex items-start gap-2 rounded-[8px] p-3 t-body-sm" style={{ background: "var(--clay-50)", color: "var(--clay-700)" }}>
           <Mail className="mt-0.5 h-4 w-4" /> Don&apos;t forget to check your spam folder.
         </div>
         <Link href="/login" className="mt-6 inline-flex items-center gap-1 t-label" style={{ color: "var(--moss-700)" }}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -96,3 +96,22 @@
 .t-label { font-weight:500; font-size:13px; line-height:1.3; letter-spacing:-.003em; }
 .t-label-sm { font-weight:500; font-size:12px; line-height:1.3; letter-spacing:-.003em; }
 .t-eyebrow { font-weight:600; font-size:10.5px; line-height:1.2; letter-spacing:.14em; text-transform:uppercase; }
+
+/* Unified form-control treatment — moss border + soft halo on focus */
+.man-field {
+  border: 1px solid var(--card-edge);
+  border-radius: 10px;
+  background: #ffffff;
+}
+.man-field:focus,
+.man-field:focus-visible {
+  outline: none;
+  border-color: var(--moss-700);
+  box-shadow: 0 0 0 3px var(--moss-100);
+}
+/* For controls whose visible border lives on a wrapper (search bars, icon+input rows) */
+.man-field-wrap:focus-within {
+  border-color: var(--moss-700);
+  box-shadow: 0 0 0 3px var(--moss-100);
+}
+.man-focusable:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--moss-100); border-radius: 6px; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -114,4 +114,5 @@
   border-color: var(--moss-700);
   box-shadow: 0 0 0 3px var(--moss-100);
 }
+.man-field-wrap { border-color: var(--card-edge); }
 .man-focusable:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--moss-100); border-radius: 6px; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -116,3 +116,7 @@
 }
 .man-field-wrap { border-color: var(--card-edge); }
 .man-focusable:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--moss-100); border-radius: 6px; }
+.man-focus:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--moss-100);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -29,7 +29,7 @@
     --border: 39 24% 88%;            /* card-edge #e8e3d8 */
     --input: 39 24% 88%;
     --ring: 147 47% 23%;
-    --radius: 0.875rem;              /* 14px cards */
+    --radius: 0.75rem;               /* 12px */
 
     /* Manaakhah raw tokens (use directly for bespoke layouts) */
     --paper:#f7f5f1; --paper-2:#efece5; --paper-3:#e4e0d6; --card-edge:#e8e3d8; --hairline:#d8d2c4;
@@ -100,7 +100,7 @@
 /* Unified form-control treatment — moss border + soft halo on focus */
 .man-field {
   border: 1px solid var(--card-edge);
-  border-radius: 10px;
+  border-radius: 8px;
   background: #ffffff;
 }
 .man-field:focus,
@@ -115,7 +115,7 @@
   box-shadow: 0 0 0 3px var(--moss-100);
 }
 .man-field-wrap { border-color: var(--card-edge); }
-.man-focusable:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--moss-100); border-radius: 6px; }
+.man-focusable:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--moss-100); border-radius: 4px; }
 .man-focus:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px var(--moss-100);

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -69,7 +69,7 @@ export default function HelpPage() {
               </details>
             </ManCard>
           ))}
-          <div className="mt-4 rounded-[14px] p-[22px]" style={{ background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
+          <div className="mt-4 rounded-[12px] p-[22px]" style={{ background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
             <div className="t-h4" style={{ color: "var(--ink-900)" }}>Still Need Help?</div>
             <p className="t-body-sm" style={{ color: "var(--ink-700)", marginTop: 6 }}>Our team replies within one business day.</p>
             <div className="mt-3.5 flex flex-wrap items-center gap-3">

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -43,9 +43,9 @@ export default function HelpPage() {
 
       <section className="mx-auto grid max-w-[1100px] gap-8 px-6 py-12 lg:grid-cols-[260px_1fr]">
         <div>
-          <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 10 }}>Categories</div>
+          <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 8 }}>Categories</div>
           {cats.map(({ Icon, t, n }) => (
-            <ManCard key={t} style={{ padding: 14, marginBottom: 8 }} className="flex items-center gap-3">
+            <ManCard key={t} style={{ padding: 16, marginBottom: 8 }} className="flex items-center gap-3">
               <Icon size={18} style={{ color: "var(--moss-700)" }} />
               <div className="flex-1">
                 <div className="t-label" style={{ color: "var(--ink-900)" }}>{t}</div>
@@ -59,19 +59,19 @@ export default function HelpPage() {
         <div>
           <PH title="Frequently Asked" sub="Updated weekly · most-asked first" />
           {faqs.map(([q, a], i) => (
-            <ManCard key={q} style={{ marginBottom: 10 }}>
-              <details open={i === 0} className="group p-[18px]">
+            <ManCard key={q} style={{ marginBottom: 8 }}>
+              <details open={i === 0} className="group p-5">
                 <summary className="t-h4 flex cursor-pointer list-none items-center justify-between gap-4" style={{ color: "var(--ink-900)", fontSize: 15.5 }}>
                   {q}
                   <span className="t-h4" style={{ color: "var(--ink-500)" }}>+</span>
                 </summary>
-                <p className="t-body" style={{ color: "var(--ink-700)", marginTop: 10 }}>{a}</p>
+                <p className="t-body" style={{ color: "var(--ink-700)", marginTop: 8 }}>{a}</p>
               </details>
             </ManCard>
           ))}
-          <div className="mt-4 rounded-[12px] p-[22px]" style={{ background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
+          <div className="mt-4 rounded-[12px] p-5" style={{ background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
             <div className="t-h4" style={{ color: "var(--ink-900)" }}>Still Need Help?</div>
-            <p className="t-body-sm" style={{ color: "var(--ink-700)", marginTop: 6 }}>Our team replies within one business day.</p>
+            <p className="t-body-sm" style={{ color: "var(--ink-700)", marginTop: 4 }}>Our team replies within one business day.</p>
             <div className="mt-3.5 flex flex-wrap items-center gap-3">
               <a href="mailto:support@manaakhah.com"><Button size="sm">Contact Support</Button></a>
               <Link href="/register" className="t-body-sm" style={{ color: "var(--moss-700)", fontWeight: 600 }}>New to Manaakhah? Create a free account →</Link>

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -29,7 +29,7 @@ export default function HelpPage() {
         <div className="mx-auto max-w-[1100px]">
           <Tag>Help Center</Tag>
           <h1 className="t-h1" style={{ color: "var(--ink-900)", marginTop: 12, fontSize: 44 }}>How Can We Help?</h1>
-          <div className="mt-5 flex max-w-[600px] items-center gap-2 rounded-full border bg-white px-4 py-3" style={{ borderColor: "var(--card-edge)" }}>
+          <div className="man-field-wrap mt-5 flex max-w-[600px] items-center gap-2 rounded-full border bg-white px-4 py-3">
             <Search size={18} style={{ color: "var(--ink-400)" }} />
             <input placeholder="Search articles, e.g. 'how to claim my listing'" className="w-full bg-transparent t-body outline-none" style={{ color: "var(--ink-900)" }} />
           </div>

--- a/app/inbox/page.tsx
+++ b/app/inbox/page.tsx
@@ -94,7 +94,7 @@ export default function InboxPage() {
             <div className="px-6 py-4" style={{ borderTop: "1px solid var(--card-edge)", background: "#ffffff" }}>
               <div className="mb-2 flex flex-wrap gap-2">
                 {QUICK.map((q) => (
-                  <button key={q} onClick={() => setDraft(q)} className="t-body-xs rounded-full px-2.5 py-1" style={{ background: "var(--paper-2)", color: "var(--ink-700)" }}>{q}</button>
+                  <button key={q} onClick={() => setDraft(q)} className="man-focus t-body-xs rounded-full px-2.5 py-1" style={{ background: "var(--paper-2)", color: "var(--ink-700)" }}>{q}</button>
                 ))}
               </div>
               <div className="man-field-wrap flex items-center gap-2 rounded-[10px] border bg-white px-3">

--- a/app/inbox/page.tsx
+++ b/app/inbox/page.tsx
@@ -45,7 +45,7 @@ export default function InboxPage() {
           {/* Thread list */}
           <div className="flex w-[340px] flex-shrink-0 flex-col" style={{ borderRight: "1px solid var(--card-edge)" }}>
             <div className="flex h-[69px] items-center px-4" style={{ borderBottom: "1px solid var(--card-edge)" }}>
-              <div className="flex w-full items-center gap-2 rounded-[10px] border px-3 py-2" style={{ borderColor: "var(--card-edge)", background: "#ffffff" }}>
+              <div className="man-field-wrap flex w-full items-center gap-2 rounded-[10px] border px-3 py-2" style={{ background: "#ffffff" }}>
                 <Search size={15} style={{ color: "var(--ink-400)" }} /><input placeholder="Search messages" className="w-full bg-transparent t-body-sm outline-none" style={{ color: "var(--ink-900)" }} />
               </div>
             </div>
@@ -97,7 +97,7 @@ export default function InboxPage() {
                   <button key={q} onClick={() => setDraft(q)} className="t-body-xs rounded-full px-2.5 py-1" style={{ background: "var(--paper-2)", color: "var(--ink-700)" }}>{q}</button>
                 ))}
               </div>
-              <div className="flex items-center gap-2 rounded-[10px] border bg-white px-3" style={{ borderColor: "var(--card-edge)" }}>
+              <div className="man-field-wrap flex items-center gap-2 rounded-[10px] border bg-white px-3">
                 <Paperclip size={18} style={{ color: "var(--ink-400)" }} />
                 <input value={draft} onChange={(e) => setDraft(e.target.value)} placeholder="Write a message…" className="w-full bg-transparent py-2.5 t-body-sm outline-none" style={{ color: "var(--ink-900)" }} />
                 <button className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full" style={{ background: "var(--moss-700)" }}><Send size={15} style={{ color: "var(--bone)" }} /></button>

--- a/app/inbox/page.tsx
+++ b/app/inbox/page.tsx
@@ -45,7 +45,7 @@ export default function InboxPage() {
           {/* Thread list */}
           <div className="flex w-[340px] flex-shrink-0 flex-col" style={{ borderRight: "1px solid var(--card-edge)" }}>
             <div className="flex h-[69px] items-center px-4" style={{ borderBottom: "1px solid var(--card-edge)" }}>
-              <div className="man-field-wrap flex w-full items-center gap-2 rounded-[10px] border px-3 py-2" style={{ background: "#ffffff" }}>
+              <div className="man-field-wrap flex w-full items-center gap-2 rounded-[8px] border px-3 py-2" style={{ background: "#ffffff" }}>
                 <Search size={15} style={{ color: "var(--ink-400)" }} /><input placeholder="Search messages" className="w-full bg-transparent t-body-sm outline-none" style={{ color: "var(--ink-900)" }} />
               </div>
             </div>
@@ -82,7 +82,7 @@ export default function InboxPage() {
               <div className="mb-4 text-center t-body-xs" style={{ color: "var(--ink-400)" }}>Conversation started</div>
               {t.msgs.map((m, i) => (
                 <div key={i} className={`mb-3 flex ${m.me ? "justify-end" : "justify-start"}`}>
-                  <div className="max-w-[70%] rounded-[14px] px-3.5 py-2.5"
+                  <div className="max-w-[70%] rounded-[12px] px-3.5 py-2.5"
                     style={m.me ? { background: "var(--moss-700)", color: "var(--bone)" } : { background: "#ffffff", border: "1px solid var(--card-edge)", color: "var(--ink-900)" }}>
                     <div className="t-body">{m.text}</div>
                     <div className="t-body-xs mt-1" style={{ color: m.me ? "rgba(255,255,255,0.7)" : "var(--ink-400)" }}>{m.time}</div>
@@ -97,7 +97,7 @@ export default function InboxPage() {
                   <button key={q} onClick={() => setDraft(q)} className="man-focus t-body-xs rounded-full px-2.5 py-1" style={{ background: "var(--paper-2)", color: "var(--ink-700)" }}>{q}</button>
                 ))}
               </div>
-              <div className="man-field-wrap flex items-center gap-2 rounded-[10px] border bg-white px-3">
+              <div className="man-field-wrap flex items-center gap-2 rounded-[8px] border bg-white px-3">
                 <Paperclip size={18} style={{ color: "var(--ink-400)" }} />
                 <input value={draft} onChange={(e) => setDraft(e.target.value)} placeholder="Write a message…" className="w-full bg-transparent py-2.5 t-body-sm outline-none" style={{ color: "var(--ink-900)" }} />
                 <button className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full" style={{ background: "var(--moss-700)" }}><Send size={15} style={{ color: "var(--bone)" }} /></button>

--- a/app/inbox/page.tsx
+++ b/app/inbox/page.tsx
@@ -41,7 +41,7 @@ export default function InboxPage() {
         <h1 className="t-h3" style={{ color: "var(--ink-900)" }}>Inbox</h1>
         <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 4 }}>Your conversations with Muslim-owned businesses</p>
 
-        <ManCard style={{ padding: 0, overflow: "hidden", marginTop: 18 }} className="flex h-[calc(100vh-200px)] min-h-[480px]">
+        <ManCard style={{ padding: 0, overflow: "hidden", marginTop: 16 }} className="flex h-[calc(100vh-200px)] min-h-[480px]">
           {/* Thread list */}
           <div className="flex w-[340px] flex-shrink-0 flex-col" style={{ borderRight: "1px solid var(--card-edge)" }}>
             <div className="flex h-[69px] items-center px-4" style={{ borderBottom: "1px solid var(--card-edge)" }}>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -68,20 +68,20 @@ function LoginContent() {
 
       <form onSubmit={handleSubmit} className="mt-8 space-y-4">
         {(verified || reset) && (
-          <div className="flex items-center gap-2 rounded-[10px] p-3 t-body-sm"
+          <div className="flex items-center gap-2 rounded-[8px] p-3 t-body-sm"
             style={{ background: "var(--moss-50)", color: "var(--moss-700)" }}>
             <CheckCircle className="h-4 w-4" />
             {verified ? "Email verified! Please sign in." : "Password reset! Sign in with your new password."}
           </div>
         )}
         {registered && (
-          <div className="flex items-center gap-2 rounded-[10px] p-3 t-body-sm"
+          <div className="flex items-center gap-2 rounded-[8px] p-3 t-body-sm"
             style={{ background: "var(--clay-50)", color: "var(--clay-700)" }}>
             <Mail className="h-4 w-4" /> Registration successful! Check your email to verify.
           </div>
         )}
         {error && (
-          <div className="rounded-[10px] p-3 t-body-sm" style={{ background: "#fadfdb", color: "#9b2e25" }}>{error}</div>
+          <div className="rounded-[8px] p-3 t-body-sm" style={{ background: "#fadfdb", color: "#9b2e25" }}>{error}</div>
         )}
 
         {/* Which experience to sign into */}

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -49,7 +49,7 @@ export default function NotificationsPage() {
             <div className="t-eyebrow mb-2" style={{ color: "var(--ink-500)" }}>{g.label}</div>
             <ManCard>
               {g.items.map((n, i) => (
-                <div key={i} className="flex items-start gap-3.5 px-[18px] py-4"
+                <div key={i} className="flex items-start gap-3.5 px-5 py-4"
                   style={{ borderBottom: i === g.items.length - 1 ? "none" : "1px solid var(--card-edge)", background: n.unread ? "var(--moss-50)" : "transparent" }}>
                   <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full" style={{ background: TONE[n.tone].bg }}>
                     <n.Icon size={16} style={{ color: TONE[n.tone].fg }} />

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -39,8 +39,8 @@ export default function NotificationsPage() {
         <PH title="Notifications" sub="Updates from your saved searches, messages and the businesses you follow" />
         <div className="mb-5 flex flex-wrap gap-2">
           {filters.map((f) => (
-            <button key={f} onClick={() => setActive(f)} className="t-body-sm rounded-full px-3 py-1.5"
-              style={active === f ? { background: "var(--ink-900)", color: "var(--bone)" } : { background: "#ffffff", border: "1px solid var(--card-edge)", color: "var(--ink-700)" }}>{f}</button>
+            <button key={f} onClick={() => setActive(f)} className="man-focus t-body-sm rounded-full px-3 py-1.5"
+              style={active === f ? { background: "var(--moss-700)", color: "var(--bone)" } : { background: "#ffffff", border: "1px solid var(--card-edge)", color: "var(--ink-700)" }}>{f}</button>
           ))}
         </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,10 +30,10 @@ export default function Home() {
           <PH title="How We Build Trust" sub="Three layers of verification, never just one badge" />
           <div className="grid gap-4 md:grid-cols-3">
             {trust.map(({ Icon, t, d }) => (
-              <ManCard key={t} style={{ padding: 22 }}>
+              <ManCard key={t} style={{ padding: 20 }}>
                 <Icon size={22} style={{ color: "var(--moss-700)" }} />
                 <div className="t-h4" style={{ color: "var(--ink-900)", marginTop: 12 }}>{t}</div>
-                <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 6 }}>{d}</p>
+                <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 4 }}>{d}</p>
               </ManCard>
             ))}
           </div>

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -80,7 +80,7 @@ function RegisterContent() {
 
       <form onSubmit={handleSubmit} className="mt-6 space-y-4">
         {error && (
-          <div className="rounded-[10px] p-3 t-body-sm" style={{ background: "#fadfdb", color: "#9b2e25" }}>{error}</div>
+          <div className="rounded-[8px] p-3 t-body-sm" style={{ background: "#fadfdb", color: "#9b2e25" }}>{error}</div>
         )}
 
         {/* role chooser — only on the generic sign-up (Claim/Add presets the role) */}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -16,22 +16,18 @@ const MapLibreMap = dynamic(() => import("@/components/map/MapLibreMap"), {
 });
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { Tag } from "@/components/man/primitives";
 import {
-  BUSINESS_CATEGORIES,
-  BUSINESS_TAGS,
   DISTANCE_OPTIONS,
   SORT_OPTIONS,
-  PRICE_RANGES,
   DEFAULT_LOCATION,
 } from "@/lib/constants";
 import { useMockSession } from "@/components/mock-session-provider";
 import { useMapSearch, type Business, type MapBounds } from "@/hooks/useMapSearch";
 import { ViewToggle, type ViewMode } from "@/components/search/ViewToggle";
 import { FilterRail } from "@/components/search/FilterRail";
+import { BusinessCard } from "@/components/business/BusinessCard";
 import { categoriesForGroup } from "@/lib/category-groups";
-import { Bookmark, MessageCircle, Heart, Star, Store, SlidersHorizontal, ChevronDown, X } from "lucide-react";
+import { Bookmark, MessageCircle, SlidersHorizontal, ChevronDown, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 function SearchContent() {
@@ -206,128 +202,6 @@ function SearchContent() {
       }));
   }, [sortedBusinesses]);
 
-  // Render business card
-  const renderBusinessCard = (business: Business, compact: boolean = false) => {
-    const img = (business as any).coverImage || (typeof (business as any).photos?.[0] === "string" ? (business as any).photos[0] : (business as any).photos?.[0]?.url);
-    const cat = BUSINESS_CATEGORIES.find((c) => c.value === business.category)?.label;
-    const price = PRICE_RANGES.find((p) => p.value === business.priceRange)?.label;
-    const fav = favorites.includes(business.id);
-    const knownTags = ((business as any).tags || [])
-      .map((t: any) => BUSINESS_TAGS.find((b) => b.value === t.tag))
-      .filter(Boolean) as { value: string; label: string }[];
-
-    // Compact = short horizontal row (used in split view alongside the map)
-    if (compact) {
-      return (
-        <Link href={`/business/${business.id}`} key={business.id} onClick={() => addToRecentlyViewed(business.id)}>
-          <div className="flex gap-3 overflow-hidden rounded-[12px] p-2.5 transition-shadow hover:shadow-[var(--shadow-rest)]"
-            style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
-            {/* Thumbnail */}
-            <div className="relative h-[84px] w-[84px] flex-shrink-0 overflow-hidden rounded-[10px]">
-              {img ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img src={img} alt={business.name} loading="lazy" className="h-full w-full object-cover" />
-              ) : (
-                <div className="flex h-full w-full items-center justify-center" style={{ background: "linear-gradient(135deg, var(--moss-100), var(--moss-200))" }}>
-                  <Store size={20} style={{ color: "var(--moss-700)" }} />
-                </div>
-              )}
-            </div>
-            {/* Content */}
-            <div className="flex min-w-0 flex-1 flex-col">
-              <div className="flex items-start justify-between gap-2">
-                <h3 className="t-label line-clamp-1" style={{ color: "var(--ink-900)" }}>{business.name}</h3>
-                <button onClick={(e) => toggleFavorite(business.id, e)} aria-label="Save" className="-mr-0.5 flex-shrink-0">
-                  <Heart size={15} fill={fav ? "var(--clay-500)" : "none"} stroke={fav ? "var(--clay-500)" : "var(--ink-400)"} />
-                </button>
-              </div>
-              <div className="mt-0.5 flex flex-wrap items-center gap-x-2 t-body-xs" style={{ color: "var(--ink-500)" }}>
-                {business.averageRating > 0 && (
-                  <span className="inline-flex items-center gap-1" style={{ color: "var(--ink-700)" }}>
-                    <Star size={12} fill="var(--clay-500)" stroke="none" />
-                    <span style={{ fontWeight: 600 }}>{business.averageRating.toFixed(1)}</span>
-                    <span style={{ color: "var(--ink-400)" }}>({business.reviewCount})</span>
-                  </span>
-                )}
-                {cat && <span>{cat}</span>}
-                {price && <span>· {price}</span>}
-              </div>
-              <p className="mt-auto pt-1 t-body-xs line-clamp-1" style={{ color: "var(--ink-500)" }}>
-                {[business.address, business.city].filter(Boolean).join(", ")}
-                {business.distance !== undefined && ` · ${business.distance.toFixed(1)} mi`}
-              </p>
-            </div>
-          </div>
-        </Link>
-      );
-    }
-
-    return (
-    <Link href={`/business/${business.id}`} key={business.id} onClick={() => addToRecentlyViewed(business.id)}>
-      <div className="h-full overflow-hidden rounded-[14px] transition-shadow hover:shadow-[var(--shadow-lift)]"
-        style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
-        <div className="relative">
-          {img ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img src={img} alt={business.name} loading="lazy" className={`${compact ? 'aspect-[16/9]' : 'aspect-video'} w-full object-cover`} />
-          ) : (
-            <div className={`${compact ? 'aspect-[16/9]' : 'aspect-video'} flex items-center justify-center`}
-              style={{ background: "linear-gradient(135deg, var(--moss-100), var(--moss-200))" }}>
-              <Store size={26} style={{ color: "var(--moss-700)" }} />
-            </div>
-          )}
-
-          <button onClick={(e) => toggleFavorite(business.id, e)} aria-label="Save"
-            className="absolute right-2.5 top-2.5 flex h-8 w-8 items-center justify-center rounded-full shadow-md transition-transform hover:scale-110"
-            style={{ background: "#ffffff" }}>
-            <Heart size={15} fill={fav ? "var(--clay-500)" : "none"} stroke={fav ? "var(--clay-500)" : "var(--ink-500)"} />
-          </button>
-
-          {price && (
-            <div className="absolute bottom-2.5 left-2.5 rounded-md px-2 py-0.5"
-              style={{ background: "rgba(17,50,30,0.78)", color: "var(--bone)", fontSize: 11 }}>{price}</div>
-          )}
-        </div>
-
-        <div style={{ padding: compact ? 14 : 16 }}>
-          <div className="flex items-start justify-between gap-2">
-            <h3 className={`${compact ? 't-label-sm' : 't-label'} line-clamp-1`} style={{ color: "var(--ink-900)" }}>{business.name}</h3>
-            {business.distance !== undefined && (
-              <span className="t-body-xs whitespace-nowrap" style={{ color: "var(--ink-500)" }}>{business.distance.toFixed(1)} mi</span>
-            )}
-          </div>
-
-          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 t-body-sm" style={{ color: "var(--ink-500)" }}>
-            {business.averageRating > 0 && (
-              <span className="inline-flex items-center gap-1" style={{ color: "var(--ink-700)" }}>
-                <Star size={13} fill="var(--clay-500)" stroke="none" />
-                <span style={{ fontWeight: 600 }}>{business.averageRating.toFixed(1)}</span>
-                <span style={{ color: "var(--ink-400)" }}>({business.reviewCount})</span>
-              </span>
-            )}
-            {cat && <span>{cat}</span>}
-          </div>
-
-          {!compact && business.description && (
-            <p className="mt-2 t-body-sm line-clamp-2" style={{ color: "var(--ink-500)" }}>{business.description}</p>
-          )}
-
-          <p className="mt-2 t-body-sm line-clamp-1" style={{ color: "var(--ink-500)" }}>{[business.address, business.city].filter(Boolean).join(", ")}</p>
-
-          {!compact && knownTags.length > 0 && (
-            <div className="mt-3 flex flex-wrap gap-1.5">
-              {knownTags.slice(0, 3).map((t) => (
-                <Tag key={t.value} tone="moss">{t.label}</Tag>
-              ))}
-              {knownTags.length > 3 && <Tag>+{knownTags.length - 3}</Tag>}
-            </div>
-          )}
-        </div>
-      </div>
-    </Link>
-    );
-  };
-
   return (
     <div className="min-h-screen" style={{ background: "var(--paper)" }}>
       {/* Search Header */}
@@ -425,8 +299,8 @@ function SearchContent() {
             ) : (
               <>
                 <div className="flex items-center justify-between mb-6">
-                  <p className="text-muted-foreground">
-                    Found <strong>{sortedBusinesses.length}</strong> businesses
+                  <p className="t-body-sm" style={{ color: "var(--ink-500)" }}>
+                    Found <strong style={{ color: "var(--ink-900)" }}>{sortedBusinesses.length}</strong> businesses
                     {userLocation && ` within ${filters.distance} miles`}
                   </p>
                   <div className="flex items-center gap-2">
@@ -449,7 +323,16 @@ function SearchContent() {
                       "flex flex-col gap-1 max-h-[600px] overflow-y-auto pr-3 transition-opacity duration-300",
                       isStale ? "opacity-50" : "opacity-100"
                     )}>
-                      {sortedBusinesses.map((business) => renderBusinessCard(business, true))}
+                      {sortedBusinesses.map((business) => (
+                        <BusinessCard
+                          key={business.id}
+                          business={business}
+                          variant="compact"
+                          isFavorite={favorites.includes(business.id)}
+                          onToggleFavorite={(e) => toggleFavorite(business.id, e)}
+                          onView={() => addToRecentlyViewed(business.id)}
+                        />
+                      ))}
                     </div>
                     {/* Map on right */}
                     <div className="h-[600px] rounded-lg overflow-hidden border sticky top-24">
@@ -470,7 +353,15 @@ function SearchContent() {
                     "grid md:grid-cols-2 lg:grid-cols-3 gap-6 transition-opacity duration-300",
                     isStale ? "opacity-50" : "opacity-100"
                   )}>
-                    {sortedBusinesses.map((business) => renderBusinessCard(business))}
+                    {sortedBusinesses.map((business) => (
+                      <BusinessCard
+                        key={business.id}
+                        business={business}
+                        isFavorite={favorites.includes(business.id)}
+                        onToggleFavorite={(e) => toggleFavorite(business.id, e)}
+                        onView={() => addToRecentlyViewed(business.id)}
+                      />
+                    ))}
                   </div>
                 )}
               </>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -285,7 +285,7 @@ function SearchContent() {
             {isLoading ? (
               <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {Array.from({ length: 6 }).map((_, i) => (
-                  <BusinessCardSkeleton key={i} />
+                  <BusinessCardSkeleton key={i} variant="grid" />
                 ))}
               </div>
             ) : sortedBusinesses.length === 0 ? (
@@ -383,7 +383,7 @@ export default function SearchPage() {
         <div className="container mx-auto max-w-6xl py-8 px-4">
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
             {Array.from({ length: 6 }).map((_, i) => (
-              <BusinessCardSkeleton key={i} />
+              <BusinessCardSkeleton key={i} variant="grid" />
             ))}
           </div>
         </div>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -10,7 +10,7 @@ const MapLibreMap = dynamic(() => import("@/components/map/MapLibreMap"), {
   ssr: false,
   loading: () => (
     <div className="h-[600px] rounded-lg flex items-center justify-center" style={{ background: "var(--paper-2)" }}>
-      <p className="text-muted-foreground">Loading map...</p>
+      <p className="t-body-sm" style={{ color: "var(--ink-500)" }}>Loading map…</p>
     </div>
   ),
 });
@@ -26,8 +26,10 @@ import { useMapSearch, type Business, type MapBounds } from "@/hooks/useMapSearc
 import { ViewToggle, type ViewMode } from "@/components/search/ViewToggle";
 import { FilterRail } from "@/components/search/FilterRail";
 import { BusinessCard } from "@/components/business/BusinessCard";
+import { BusinessCardSkeleton } from "@/components/man/Skeleton";
+import { EmptyState } from "@/components/man/EmptyState";
 import { categoriesForGroup } from "@/lib/category-groups";
-import { Bookmark, MessageCircle, SlidersHorizontal, ChevronDown, X } from "lucide-react";
+import { Bookmark, MessageCircle, SlidersHorizontal, ChevronDown, X, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 function SearchContent() {
@@ -281,21 +283,22 @@ function SearchContent() {
           {/* Results */}
           <div>
             {isLoading ? (
-              <div className="text-center py-12">
-                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-                <p className="text-muted-foreground">Finding businesses near you...</p>
+              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <BusinessCardSkeleton key={i} />
+                ))}
               </div>
             ) : sortedBusinesses.length === 0 ? (
-              <div className="text-center py-12">
-                <div className="text-6xl mb-4">🔍</div>
-                <p className="text-muted-foreground mb-4">No businesses found</p>
-                <p className="text-sm text-muted-foreground mb-4">
-                  Try adjusting your search filters or expanding your search radius
-                </p>
-                <Button variant="outline" onClick={clearFilters}>
-                  Clear Filters
-                </Button>
-              </div>
+              <EmptyState
+                Icon={Search}
+                title="No businesses found"
+                description="Try adjusting your search filters or expanding your search radius."
+                action={
+                  <Button variant="outline" onClick={clearFilters}>
+                    Clear Filters
+                  </Button>
+                }
+              />
             ) : (
               <>
                 <div className="flex items-center justify-between mb-6">
@@ -376,10 +379,13 @@ function SearchContent() {
 export default function SearchPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--moss-700)] mx-auto"></div>
-          <p className="mt-4 text-muted-foreground">Loading search...</p>
+      <div className="min-h-screen" style={{ background: "var(--paper)" }}>
+        <div className="container mx-auto max-w-6xl py-8 px-4">
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <BusinessCardSkeleton key={i} />
+            ))}
+          </div>
         </div>
       </div>
     }>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -22,7 +22,7 @@ import {
   DEFAULT_LOCATION,
 } from "@/lib/constants";
 import { useMockSession } from "@/components/mock-session-provider";
-import { useMapSearch, type Business, type MapBounds } from "@/hooks/useMapSearch";
+import { useMapSearch, type MapBounds } from "@/hooks/useMapSearch";
 import { ViewToggle, type ViewMode } from "@/components/search/ViewToggle";
 import { FilterRail } from "@/components/search/FilterRail";
 import { BusinessCard } from "@/components/business/BusinessCard";
@@ -283,11 +283,19 @@ function SearchContent() {
           {/* Results */}
           <div>
             {isLoading ? (
-              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {Array.from({ length: 6 }).map((_, i) => (
-                  <BusinessCardSkeleton key={i} variant="grid" />
-                ))}
-              </div>
+              viewMode === "split" ? (
+                <div className="flex flex-col gap-1">
+                  {Array.from({ length: 6 }).map((_, i) => (
+                    <BusinessCardSkeleton key={i} variant="compact" />
+                  ))}
+                </div>
+              ) : (
+                <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {Array.from({ length: 6 }).map((_, i) => (
+                    <BusinessCardSkeleton key={i} variant="grid" />
+                  ))}
+                </div>
+              )
             ) : sortedBusinesses.length === 0 ? (
               <EmptyState
                 Icon={Search}
@@ -338,7 +346,7 @@ function SearchContent() {
                       ))}
                     </div>
                     {/* Map on right */}
-                    <div className="h-[600px] rounded-lg overflow-hidden border sticky top-24">
+                    <div className="h-[600px] rounded-lg overflow-hidden border sticky top-24" style={{ borderColor: "var(--card-edge)" }}>
                       <MapLibreMap
                         businesses={businessesForMap}
                         userLat={userLocation?.lat ?? 37.5485}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -237,7 +237,7 @@ function SearchContent() {
               </Button>
               {filtersOpen && (
                 <div
-                  className="absolute left-0 z-50 mt-2 w-[min(340px,calc(100vw-2rem))] overflow-auto rounded-[14px] border p-2 sm:left-auto sm:right-0"
+                  className="absolute left-0 z-50 mt-2 w-[min(340px,calc(100vw-2rem))] overflow-auto rounded-[12px] border p-2 sm:left-auto sm:right-0"
                   style={{ background: "#ffffff", borderColor: "var(--card-edge)", boxShadow: "var(--shadow-lift)", maxHeight: "70vh" }}
                 >
                   <FilterRail filters={filters} setFilters={setFilters} clearFilters={clearFilters} activeCount={activeFilterCount} />
@@ -258,7 +258,7 @@ function SearchContent() {
       <div className="container mx-auto max-w-6xl py-8 px-4">
         {/* Guest rail — limited, but intentional (not broken) */}
         {!session && !guestDismissed && (
-          <div className="relative mb-6 flex flex-wrap items-center gap-4 rounded-[14px] py-4 pl-5 pr-12"
+          <div className="relative mb-6 flex flex-wrap items-center gap-4 rounded-[12px] py-4 pl-5 pr-12"
             style={{ background: "var(--moss-50)", border: "1px solid var(--moss-200)" }}>
             <div className="flex items-center gap-2.5">
               <span className="flex h-9 w-9 items-center justify-center rounded-full" style={{ background: "var(--moss-700)" }}><Bookmark size={16} style={{ color: "var(--bone)" }} /></span>

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -11,7 +11,7 @@ export function LanguageSwitcher() {
       <Button variant="outline" size="sm" className="min-w-[80px]">
         {languageNames[language]}
       </Button>
-      <div className="absolute right-0 mt-1 w-32 bg-white border rounded-lg shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50">
+      <div className="absolute right-0 mt-1 w-32 bg-white border rounded-lg shadow-[var(--shadow-lift)] opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50">
         {availableLanguages.map((lang) => (
           <button
             key={lang}

--- a/components/business/BusinessCard.tsx
+++ b/components/business/BusinessCard.tsx
@@ -96,7 +96,7 @@ export function BusinessCard({
           )}
 
           <button onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggleFavorite?.(e); }} aria-label="Save"
-            className="absolute right-2.5 top-2.5 flex h-8 w-8 items-center justify-center rounded-full shadow-md transition-transform hover:scale-110"
+            className="absolute right-2.5 top-2.5 flex h-8 w-8 items-center justify-center rounded-full shadow-[var(--shadow-rest)] transition-transform hover:scale-110"
             style={{ background: "#ffffff" }}>
             <Heart size={15} fill={isFavorite ? "var(--clay-500)" : "none"} stroke={isFavorite ? "var(--clay-500)" : "var(--ink-500)"} />
           </button>

--- a/components/business/BusinessCard.tsx
+++ b/components/business/BusinessCard.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { Heart, Star, Store } from "lucide-react";
+import { Tag } from "@/components/man/primitives";
+import { BUSINESS_CATEGORIES, BUSINESS_TAGS, PRICE_RANGES } from "@/lib/constants";
+import type { Business } from "@/hooks/useMapSearch";
+
+function resolveImage(b: Business): string | undefined {
+  const cover = (b as any).coverImage;
+  if (cover) return cover;
+  const first = (b as any).photos?.[0];
+  if (!first) return undefined;
+  return typeof first === "string" ? first : first.url;
+}
+
+export function BusinessCard({
+  business,
+  variant = "grid",
+  isFavorite = false,
+  onToggleFavorite,
+  onView,
+}: {
+  business: Business;
+  variant?: "grid" | "compact";
+  isFavorite?: boolean;
+  onToggleFavorite?: (e: React.MouseEvent) => void;
+  onView?: () => void;
+}) {
+  const img = resolveImage(business);
+  const cat = BUSINESS_CATEGORIES.find((c) => c.value === business.category)?.label;
+  const price = PRICE_RANGES.find((p) => p.value === business.priceRange)?.label;
+  const knownTags = (business.tags || [])
+    .map((t) => BUSINESS_TAGS.find((bt) => bt.value === t.tag))
+    .filter(Boolean) as { value: string; label: string }[];
+
+  // Compact = short horizontal row (used in split view alongside the map)
+  if (variant === "compact") {
+    return (
+      <Link href={`/business/${business.id}`} onClick={onView}>
+        <div className="flex gap-3 overflow-hidden rounded-[12px] p-2.5 transition-shadow hover:shadow-[var(--shadow-rest)]"
+          style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
+          <div className="relative h-[84px] w-[84px] flex-shrink-0 overflow-hidden rounded-[10px]">
+            {img ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={img} alt={business.name} loading="lazy" className="h-full w-full object-cover" />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center" style={{ background: "linear-gradient(135deg, var(--moss-100), var(--moss-200))" }}>
+                <Store size={20} style={{ color: "var(--moss-700)" }} />
+              </div>
+            )}
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col">
+            <div className="flex items-start justify-between gap-2">
+              <h3 className="t-label line-clamp-1" style={{ color: "var(--ink-900)" }}>{business.name}</h3>
+              <button onClick={onToggleFavorite} aria-label="Save" className="-mr-0.5 flex-shrink-0">
+                <Heart size={15} fill={isFavorite ? "var(--clay-500)" : "none"} stroke={isFavorite ? "var(--clay-500)" : "var(--ink-400)"} />
+              </button>
+            </div>
+            <div className="mt-0.5 flex flex-wrap items-center gap-x-2 t-body-xs" style={{ color: "var(--ink-500)" }}>
+              {business.averageRating > 0 && (
+                <span className="inline-flex items-center gap-1" style={{ color: "var(--ink-700)" }}>
+                  <Star size={12} fill="var(--clay-500)" stroke="none" />
+                  <span style={{ fontWeight: 600 }}>{business.averageRating.toFixed(1)}</span>
+                  <span style={{ color: "var(--ink-400)" }}>({business.reviewCount})</span>
+                </span>
+              )}
+              {cat && <span>{cat}</span>}
+              {price && <span>· {price}</span>}
+            </div>
+            <p className="mt-auto pt-1 t-body-xs line-clamp-1" style={{ color: "var(--ink-500)" }}>
+              {[business.address, business.city].filter(Boolean).join(", ")}
+              {business.distance !== undefined && ` · ${business.distance.toFixed(1)} mi`}
+            </p>
+          </div>
+        </div>
+      </Link>
+    );
+  }
+
+  // Grid = vertical card (default)
+  return (
+    <Link href={`/business/${business.id}`} onClick={onView}>
+      <div className="h-full overflow-hidden rounded-[14px] transition-shadow hover:shadow-[var(--shadow-lift)]"
+        style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
+        <div className="relative">
+          {img ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={img} alt={business.name} loading="lazy" className="aspect-video w-full object-cover" />
+          ) : (
+            <div className="aspect-video flex items-center justify-center"
+              style={{ background: "linear-gradient(135deg, var(--moss-100), var(--moss-200))" }}>
+              <Store size={26} style={{ color: "var(--moss-700)" }} />
+            </div>
+          )}
+
+          <button onClick={onToggleFavorite} aria-label="Save"
+            className="absolute right-2.5 top-2.5 flex h-8 w-8 items-center justify-center rounded-full shadow-md transition-transform hover:scale-110"
+            style={{ background: "#ffffff" }}>
+            <Heart size={15} fill={isFavorite ? "var(--clay-500)" : "none"} stroke={isFavorite ? "var(--clay-500)" : "var(--ink-500)"} />
+          </button>
+
+          {price && (
+            <div className="absolute bottom-2.5 left-2.5 rounded-md px-2 py-0.5"
+              style={{ background: "rgba(17,50,30,0.78)", color: "var(--bone)", fontSize: 11 }}>{price}</div>
+          )}
+        </div>
+
+        <div style={{ padding: 16 }}>
+          <div className="flex items-start justify-between gap-2">
+            <h3 className="t-label line-clamp-1" style={{ color: "var(--ink-900)" }}>{business.name}</h3>
+            {business.distance !== undefined && (
+              <span className="t-body-xs whitespace-nowrap" style={{ color: "var(--ink-500)" }}>{business.distance.toFixed(1)} mi</span>
+            )}
+          </div>
+
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 t-body-sm" style={{ color: "var(--ink-500)" }}>
+            {business.averageRating > 0 && (
+              <span className="inline-flex items-center gap-1" style={{ color: "var(--ink-700)" }}>
+                <Star size={13} fill="var(--clay-500)" stroke="none" />
+                <span style={{ fontWeight: 600 }}>{business.averageRating.toFixed(1)}</span>
+                <span style={{ color: "var(--ink-400)" }}>({business.reviewCount})</span>
+              </span>
+            )}
+            {cat && <span>{cat}</span>}
+          </div>
+
+          {business.description && (
+            <p className="mt-2 t-body-sm line-clamp-2" style={{ color: "var(--ink-500)" }}>{business.description}</p>
+          )}
+
+          <p className="mt-2 t-body-sm line-clamp-1" style={{ color: "var(--ink-500)" }}>{[business.address, business.city].filter(Boolean).join(", ")}</p>
+
+          {knownTags.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {knownTags.slice(0, 3).map((t) => (
+                <Tag key={t.value} tone="moss">{t.label}</Tag>
+              ))}
+              {knownTags.length > 3 && <Tag>+{knownTags.length - 3}</Tag>}
+            </div>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/components/business/BusinessCard.tsx
+++ b/components/business/BusinessCard.tsx
@@ -54,7 +54,7 @@ export function BusinessCard({
           <div className="flex min-w-0 flex-1 flex-col">
             <div className="flex items-start justify-between gap-2">
               <h3 className="t-label line-clamp-1" style={{ color: "var(--ink-900)" }}>{business.name}</h3>
-              <button onClick={onToggleFavorite} aria-label="Save" className="-mr-0.5 flex-shrink-0">
+              <button onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggleFavorite?.(e); }} aria-label="Save" className="-mr-0.5 flex-shrink-0">
                 <Heart size={15} fill={isFavorite ? "var(--clay-500)" : "none"} stroke={isFavorite ? "var(--clay-500)" : "var(--ink-400)"} />
               </button>
             </div>
@@ -95,7 +95,7 @@ export function BusinessCard({
             </div>
           )}
 
-          <button onClick={onToggleFavorite} aria-label="Save"
+          <button onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggleFavorite?.(e); }} aria-label="Save"
             className="absolute right-2.5 top-2.5 flex h-8 w-8 items-center justify-center rounded-full shadow-md transition-transform hover:scale-110"
             style={{ background: "#ffffff" }}>
             <Heart size={15} fill={isFavorite ? "var(--clay-500)" : "none"} stroke={isFavorite ? "var(--clay-500)" : "var(--ink-500)"} />

--- a/components/business/BusinessCard.tsx
+++ b/components/business/BusinessCard.tsx
@@ -41,7 +41,7 @@ export function BusinessCard({
       <Link href={`/business/${business.id}`} onClick={onView}>
         <div className="flex gap-3 overflow-hidden rounded-[12px] p-2.5 transition-shadow hover:shadow-[var(--shadow-rest)]"
           style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
-          <div className="relative h-[84px] w-[84px] flex-shrink-0 overflow-hidden rounded-[10px]">
+          <div className="relative h-[84px] w-[84px] flex-shrink-0 overflow-hidden rounded-[8px]">
             {img ? (
               // eslint-disable-next-line @next/next/no-img-element
               <img src={img} alt={business.name} loading="lazy" className="h-full w-full object-cover" />
@@ -82,7 +82,7 @@ export function BusinessCard({
   // Grid = vertical card (default)
   return (
     <Link href={`/business/${business.id}`} onClick={onView}>
-      <div className="h-full overflow-hidden rounded-[14px] transition-shadow hover:shadow-[var(--shadow-lift)]"
+      <div className="h-full overflow-hidden rounded-[12px] transition-shadow hover:shadow-[var(--shadow-lift)]"
         style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
         <div className="relative">
           {img ? (

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -106,12 +106,12 @@ export function Header() {
         ) : (
           <>
             {!isAdmin && (
-              <Link href={notifHref} className="hidden rounded-full p-2 hover:bg-[var(--paper-2)] md:block" aria-label="Notifications">
+              <Link href={notifHref} className="man-focus hidden rounded-full p-2 hover:bg-[var(--paper-2)] md:block" aria-label="Notifications">
                 <Bell className="h-5 w-5" style={{ color: "var(--ink-500)" }} />
               </Link>
             )}
             <div ref={acctRef} className="relative">
-              <button onClick={() => setAcctOpen((o) => !o)} className="flex items-center gap-1.5" aria-label="Account menu">
+              <button onClick={() => setAcctOpen((o) => !o)} className="man-focus flex items-center gap-1.5 rounded-full" aria-label="Account menu">
                 <Avatar name={session?.user?.name || "User"} size={32} />
                 <ChevronDown className="hidden h-4 w-4 md:block" style={{ color: "var(--ink-400)", transform: acctOpen ? "rotate(180deg)" : "none", transition: "transform 0.15s" }} />
               </button>
@@ -152,7 +152,7 @@ export function Header() {
             </div>
           </>
         )}
-        <button className="md:hidden" onClick={() => setMobileOpen((o) => !o)} aria-label="Menu">
+        <button className="man-focus rounded-[6px] md:hidden" onClick={() => setMobileOpen((o) => !o)} aria-label="Menu">
           {mobileOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
         </button>
       </div>
@@ -162,7 +162,7 @@ export function Header() {
         <div className="absolute left-0 right-0 top-16 border-b bg-white p-4 md:hidden" style={{ borderColor: "var(--card-edge)" }}>
           <nav className="flex flex-col gap-1">
             {tabs.map((t) => (
-              <Link key={t.href} href={t.href} onClick={() => setMobileOpen(false)} className="rounded-lg px-3 py-2 t-body" style={{ color: "var(--ink-700)" }}>{t.l}</Link>
+              <Link key={t.href} href={t.href} onClick={() => setMobileOpen(false)} className="man-focus rounded-lg px-3 py-2 t-body" style={{ color: "var(--ink-700)" }}>{t.l}</Link>
             ))}
             {!signedIn && (
               <div className="mt-2 flex gap-2 border-t pt-3" style={{ borderColor: "var(--card-edge)" }}>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -152,7 +152,7 @@ export function Header() {
             </div>
           </>
         )}
-        <button className="man-focus rounded-[6px] md:hidden" onClick={() => setMobileOpen((o) => !o)} aria-label="Menu">
+        <button className="man-focus rounded-[4px] md:hidden" onClick={() => setMobileOpen((o) => !o)} aria-label="Menu">
           {mobileOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
         </button>
       </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -88,7 +88,7 @@ export function Header() {
         </Link>
         <nav className="hidden items-center gap-1 md:flex">
           {tabs.map((t) => (
-            <Link key={t.href} href={t.href} className="rounded-lg px-3 py-2"
+            <Link key={t.href} href={t.href} className="man-focus rounded-lg px-3 py-2"
               style={{ fontSize: 13, fontWeight: 500, color: isActive(t.href) ? "var(--ink-900)" : "var(--ink-500)", background: isActive(t.href) ? "#ffffff" : "transparent" }}>
               {t.l}
             </Link>
@@ -127,7 +127,7 @@ export function Header() {
                   {isConsumer && (
                     <div className="py-1" style={{ borderBottom: "1px solid var(--card-edge)" }}>
                       {acctLinks.map((it) => (
-                        <Link key={it.href} href={it.href} onClick={() => setAcctOpen(false)} className="flex items-center gap-2.5 px-4 py-2.5 t-body-sm hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-700)" }}>
+                        <Link key={it.href} href={it.href} onClick={() => setAcctOpen(false)} className="man-focus flex items-center gap-2.5 px-4 py-2.5 t-body-sm hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-700)" }}>
                           <it.Icon size={16} style={{ color: "var(--ink-500)" }} /> {it.l}
                         </Link>
                       ))}
@@ -136,16 +136,16 @@ export function Header() {
                   {!isAdmin && (
                     <div className="py-1" style={{ borderTop: "1px solid var(--card-edge)" }}>
                       <div className="px-4 pb-1 pt-1.5 t-eyebrow" style={{ color: "var(--ink-500)" }}>Switch account</div>
-                      <button onClick={() => switchTo("CONSUMER")} className="flex w-full items-center gap-2.5 px-4 py-2.5 text-left t-body-sm hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-700)" }}>
+                      <button onClick={() => switchTo("CONSUMER")} className="man-focus flex w-full items-center gap-2.5 px-4 py-2.5 text-left t-body-sm hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-700)" }}>
                         <User size={16} style={{ color: "var(--ink-500)" }} /> <span className="flex-1">Customer</span> {role === "CONSUMER" && <Check size={15} style={{ color: "var(--moss-700)" }} />}
                       </button>
-                      <button onClick={() => switchTo("BUSINESS_OWNER")} className="flex w-full items-center gap-2.5 px-4 py-2.5 text-left t-body-sm hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-700)" }}>
+                      <button onClick={() => switchTo("BUSINESS_OWNER")} className="man-focus flex w-full items-center gap-2.5 px-4 py-2.5 text-left t-body-sm hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-700)" }}>
                         <Store size={16} style={{ color: "var(--ink-500)" }} /> <span className="flex-1">Business</span> {role === "BUSINESS_OWNER" && <Check size={15} style={{ color: "var(--moss-700)" }} />}
                       </button>
                     </div>
                   )}
                   <div className="py-1" style={{ borderTop: "1px solid var(--card-edge)" }}>
-                    <button onClick={() => { setAcctOpen(false); signOut(); }} className="flex w-full items-center gap-2.5 px-4 py-2.5 text-left t-body-sm hover:bg-[var(--paper-2)]" style={{ color: "var(--err-500)" }}><LogOut size={16} /> Sign Out</button>
+                    <button onClick={() => { setAcctOpen(false); signOut(); }} className="man-focus flex w-full items-center gap-2.5 px-4 py-2.5 text-left t-body-sm hover:bg-[var(--paper-2)]" style={{ color: "var(--err-500)" }}><LogOut size={16} /> Sign Out</button>
                   </div>
                 </div>
               )}

--- a/components/help/AuthedHelp.tsx
+++ b/components/help/AuthedHelp.tsx
@@ -47,7 +47,7 @@ export function AuthedHelp({ role }: { role: "consumer" | "owner" }) {
         <div className="grid gap-3.5">
           {/* Search */}
           <ManCard style={{ padding: 18 }}>
-            <div className="flex items-center gap-2 rounded-[10px] border bg-white px-3.5 py-2.5" style={{ borderColor: "var(--card-edge)" }}>
+            <div className="man-field-wrap flex items-center gap-2 rounded-[10px] border bg-white px-3.5 py-2.5">
               <Search size={18} style={{ color: "var(--ink-400)" }} />
               <input placeholder="Search help articles…" className="w-full bg-transparent t-body outline-none" style={{ color: "var(--ink-900)" }} />
             </div>

--- a/components/help/AuthedHelp.tsx
+++ b/components/help/AuthedHelp.tsx
@@ -46,7 +46,7 @@ export function AuthedHelp({ role }: { role: "consumer" | "owner" }) {
       <div className="grid gap-3.5 lg:grid-cols-[1.6fr_1fr]">
         <div className="grid gap-3.5">
           {/* Search */}
-          <ManCard style={{ padding: 18 }}>
+          <ManCard style={{ padding: 20 }}>
             <div className="man-field-wrap flex items-center gap-2 rounded-[8px] border bg-white px-3.5 py-2.5">
               <Search size={18} style={{ color: "var(--ink-400)" }} />
               <input placeholder="Search help articles…" className="w-full bg-transparent t-body outline-none" style={{ color: "var(--ink-900)" }} />
@@ -79,7 +79,7 @@ export function AuthedHelp({ role }: { role: "consumer" | "owner" }) {
             ))}
           </ManCard>
 
-          <ManCard style={{ padding: 22 }}>
+          <ManCard style={{ padding: 20 }}>
             <div className="t-h4" style={{ color: "var(--ink-900)" }}>Contact Support</div>
             <div className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 2 }}>Typical reply within {role === "owner" ? "2 hours" : "1 business day"}.</div>
             <div className="mt-3.5 grid gap-2">

--- a/components/help/AuthedHelp.tsx
+++ b/components/help/AuthedHelp.tsx
@@ -47,7 +47,7 @@ export function AuthedHelp({ role }: { role: "consumer" | "owner" }) {
         <div className="grid gap-3.5">
           {/* Search */}
           <ManCard style={{ padding: 18 }}>
-            <div className="man-field-wrap flex items-center gap-2 rounded-[10px] border bg-white px-3.5 py-2.5">
+            <div className="man-field-wrap flex items-center gap-2 rounded-[8px] border bg-white px-3.5 py-2.5">
               <Search size={18} style={{ color: "var(--ink-400)" }} />
               <input placeholder="Search help articles…" className="w-full bg-transparent t-body outline-none" style={{ color: "var(--ink-900)" }} />
             </div>

--- a/components/home/CategoryGroupGrid.tsx
+++ b/components/home/CategoryGroupGrid.tsx
@@ -23,7 +23,7 @@ export function CategoryGroupGrid() {
           const Icon = ICONS[g.icon] ?? Briefcase;
           return (
             <Link key={g.key} href={`/search?group=${g.key}`}>
-              <ManCard style={{ padding: 18 }} className="flex h-full items-center gap-3.5 transition-shadow hover:shadow-[var(--shadow-lift)]">
+              <ManCard style={{ padding: 20 }} className="flex h-full items-center gap-3.5 transition-shadow hover:shadow-[var(--shadow-lift)]">
                 <span className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl" style={{ background: "var(--moss-50)" }}>
                   <Icon size={20} style={{ color: "var(--moss-700)" }} />
                 </span>

--- a/components/home/FeaturedRow.tsx
+++ b/components/home/FeaturedRow.tsx
@@ -26,7 +26,7 @@ export function FeaturedRow() {
             <ManCard style={{ padding: 0, overflow: "hidden" }} className="h-full transition-shadow hover:shadow-[var(--shadow-lift)]">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={b.coverImage} alt={b.name} loading="lazy" className="aspect-video w-full object-cover" />
-              <div style={{ padding: 14 }}>
+              <div style={{ padding: 16 }}>
                 <div className="t-label line-clamp-1" style={{ color: "var(--ink-900)" }}>{b.name}</div>
                 <div className="mt-1 flex items-center gap-2 t-body-sm" style={{ color: "var(--ink-500)" }}>
                   {b.averageRating > 0 && (

--- a/components/home/FeaturedShowcase.tsx
+++ b/components/home/FeaturedShowcase.tsx
@@ -24,7 +24,7 @@ export function FeaturedShowcase() {
   const s = slides[i];
 
   return (
-    <div className="relative h-[440px] w-full overflow-hidden rounded-[14px]" style={{ boxShadow: "var(--shadow-lift)" }}>
+    <div className="relative h-[440px] w-full overflow-hidden rounded-[12px]" style={{ boxShadow: "var(--shadow-lift)" }}>
       {/* rotating photo panels with moss scrim for legibility */}
       {slides.map((sl, idx) => (
         <div key={sl.name} className="absolute inset-0 transition-opacity duration-700"
@@ -37,7 +37,7 @@ export function FeaturedShowcase() {
       ))}
 
       {/* floating info card */}
-      <div className="absolute bottom-5 left-5 right-5 rounded-[14px] border bg-white p-4"
+      <div className="absolute bottom-5 left-5 right-5 rounded-[12px] border bg-white p-4"
         style={{ borderColor: "var(--card-edge)", boxShadow: "var(--shadow-lift)" }}>
         <div className="flex items-start justify-between gap-3">
           <div>

--- a/components/home/HeroSearch.tsx
+++ b/components/home/HeroSearch.tsx
@@ -26,7 +26,7 @@ export function HeroSearch() {
         {/* Left: brand + search (left-aligned — our signature, not Taawun's centered hero) */}
         <div>
           <Tag tone="moss">Sacramento&apos;s Muslim Business Directory</Tag>
-          <h1 className="t-display" style={{ color: "var(--ink-900)", marginTop: 18 }}>
+          <h1 className="t-display" style={{ color: "var(--ink-900)", marginTop: 16 }}>
             Where the Muslim Community<br className="hidden sm:block" /> <span style={{ fontStyle: "italic" }}>does business</span>.
           </h1>
           <p className="t-body-lg" style={{ color: "var(--ink-500)", marginTop: 16, maxWidth: 520 }}>

--- a/components/home/HeroSearch.tsx
+++ b/components/home/HeroSearch.tsx
@@ -33,7 +33,7 @@ export function HeroSearch() {
             Discover and support Muslim-owned businesses near you — restaurants, grocers, salons, services and more, trusted by your community.
           </p>
 
-          <form onSubmit={submit} className="man-field-wrap mt-7 flex w-full flex-col gap-2 rounded-[14px] border bg-white p-2 shadow-[var(--shadow-lift)] sm:flex-row sm:items-center">
+          <form onSubmit={submit} className="man-field-wrap mt-7 flex w-full flex-col gap-2 rounded-[12px] border bg-white p-2 shadow-[var(--shadow-lift)] sm:flex-row sm:items-center">
             <div className="flex flex-1 items-center gap-2 px-3 sm:min-w-[200px]">
               <Search size={18} className="flex-shrink-0" style={{ color: "var(--ink-400)" }} />
               <input value={term} onChange={(e) => setTerm(e.target.value)} placeholder="Search businesses…"

--- a/components/home/HeroSearch.tsx
+++ b/components/home/HeroSearch.tsx
@@ -33,7 +33,7 @@ export function HeroSearch() {
             Discover and support Muslim-owned businesses near you — restaurants, grocers, salons, services and more, trusted by your community.
           </p>
 
-          <form onSubmit={submit} className="mt-7 flex w-full flex-col gap-2 rounded-[14px] border bg-white p-2 shadow-[var(--shadow-lift)] sm:flex-row sm:items-center" style={{ borderColor: "var(--card-edge)" }}>
+          <form onSubmit={submit} className="man-field-wrap mt-7 flex w-full flex-col gap-2 rounded-[14px] border bg-white p-2 shadow-[var(--shadow-lift)] sm:flex-row sm:items-center">
             <div className="flex flex-1 items-center gap-2 px-3 sm:min-w-[200px]">
               <Search size={18} className="flex-shrink-0" style={{ color: "var(--ink-400)" }} />
               <input value={term} onChange={(e) => setTerm(e.target.value)} placeholder="Search businesses…"

--- a/components/man/Choice.tsx
+++ b/components/man/Choice.tsx
@@ -29,7 +29,7 @@ export function Checkbox({
       className={`man-focusable inline-flex items-center gap-2 text-left disabled:opacity-50 ${className}`}
     >
       <span
-        className="flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-[5px] transition-colors"
+        className="flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-[4px] transition-colors"
         style={cur
           ? { background: "var(--moss-700)", border: "1.5px solid var(--moss-700)" }
           : { background: "var(--card)", border: "1.5px solid var(--card-edge)" }}

--- a/components/man/Choice.tsx
+++ b/components/man/Choice.tsx
@@ -26,7 +26,7 @@ export function Checkbox({
       aria-checked={cur}
       disabled={disabled}
       onClick={toggle}
-      className={`inline-flex items-center gap-2 text-left disabled:opacity-50 ${className}`}
+      className={`man-focusable inline-flex items-center gap-2 text-left disabled:opacity-50 ${className}`}
     >
       <span
         className="flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-[5px] transition-colors"
@@ -58,7 +58,7 @@ export function Radio({
       aria-checked={checked}
       disabled={disabled}
       onClick={onChange}
-      className={`inline-flex items-center gap-2 text-left disabled:opacity-50 ${className}`}
+      className={`man-focusable inline-flex items-center gap-2 text-left disabled:opacity-50 ${className}`}
     >
       <span
         className="flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-full transition-colors"

--- a/components/man/DatePicker.tsx
+++ b/components/man/DatePicker.tsx
@@ -57,7 +57,7 @@ export function DatePicker({
         disabled={disabled}
         onClick={() => setOpen((o) => !o)}
         className="flex w-full items-center justify-between gap-2 rounded-[10px] border bg-white px-3.5 py-2.5 t-body outline-none disabled:opacity-50"
-        style={{ borderColor: open ? "var(--moss-700)" : "var(--card-edge)", color: cur ? "var(--ink-900)" : "var(--ink-400)" }}
+        style={{ borderColor: open ? "var(--moss-700)" : "var(--card-edge)", boxShadow: open ? "0 0 0 3px var(--moss-100)" : "none", color: cur ? "var(--ink-900)" : "var(--ink-400)" }}
       >
         <span>{cur ? fmt(cur) : placeholder}</span>
         <Calendar size={16} style={{ color: "var(--ink-400)", flexShrink: 0 }} />

--- a/components/man/DatePicker.tsx
+++ b/components/man/DatePicker.tsx
@@ -56,7 +56,7 @@ export function DatePicker({
         type="button"
         disabled={disabled}
         onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center justify-between gap-2 rounded-[10px] border bg-white px-3.5 py-2.5 t-body outline-none disabled:opacity-50"
+        className="flex w-full items-center justify-between gap-2 rounded-[8px] border bg-white px-3.5 py-2.5 t-body outline-none disabled:opacity-50"
         style={{ borderColor: open ? "var(--moss-700)" : "var(--card-edge)", boxShadow: open ? "0 0 0 3px var(--moss-100)" : "none", color: cur ? "var(--ink-900)" : "var(--ink-400)" }}
       >
         <span>{cur ? fmt(cur) : placeholder}</span>

--- a/components/man/EmptyState.tsx
+++ b/components/man/EmptyState.tsx
@@ -20,7 +20,7 @@ export function EmptyState({
       </span>
       <h3 className="t-h4" style={{ color: "var(--ink-900)", marginTop: 16 }}>{title}</h3>
       {description && (
-        <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 6, maxWidth: 360 }}>{description}</p>
+        <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 4, maxWidth: 360 }}>{description}</p>
       )}
       {action && <div className="mt-5">{action}</div>}
     </div>

--- a/components/man/EmptyState.tsx
+++ b/components/man/EmptyState.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { type LucideIcon } from "lucide-react";
+
+/* ── EmptyState: icon + title + description + optional action ───── */
+export function EmptyState({
+  Icon,
+  title,
+  description,
+  action,
+}: {
+  Icon: LucideIcon;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center px-6 py-16 text-center">
+      <span className="flex h-14 w-14 items-center justify-center rounded-full" style={{ background: "var(--paper-2)" }}>
+        <Icon size={24} style={{ color: "var(--ink-400)" }} />
+      </span>
+      <h3 className="t-h4" style={{ color: "var(--ink-900)", marginTop: 16 }}>{title}</h3>
+      {description && (
+        <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 6, maxWidth: 360 }}>{description}</p>
+      )}
+      {action && <div className="mt-5">{action}</div>}
+    </div>
+  );
+}

--- a/components/man/EmptyState.tsx
+++ b/components/man/EmptyState.tsx
@@ -16,7 +16,7 @@ export function EmptyState({
   return (
     <div className="flex flex-col items-center justify-center px-6 py-16 text-center">
       <span className="flex h-14 w-14 items-center justify-center rounded-full" style={{ background: "var(--paper-2)" }}>
-        <Icon size={24} style={{ color: "var(--ink-400)" }} />
+        <Icon size={24} aria-hidden="true" style={{ color: "var(--ink-400)" }} />
       </span>
       <h3 className="t-h4" style={{ color: "var(--ink-900)", marginTop: 16 }}>{title}</h3>
       {description && (

--- a/components/man/Select.tsx
+++ b/components/man/Select.tsx
@@ -40,7 +40,7 @@ export function Select({
         disabled={disabled}
         onClick={() => setOpen((o) => !o)}
         className="flex w-full items-center justify-between gap-2 rounded-[10px] border bg-white px-3.5 py-2.5 t-body outline-none transition-colors disabled:opacity-50"
-        style={{ borderColor: open ? "var(--moss-700)" : "var(--card-edge)", color: selected ? "var(--ink-900)" : "var(--ink-400)" }}
+        style={{ borderColor: open ? "var(--moss-700)" : "var(--card-edge)", boxShadow: open ? "0 0 0 3px var(--moss-100)" : "none", color: selected ? "var(--ink-900)" : "var(--ink-400)" }}
       >
         <span className="truncate">{selected ? selected.label : placeholder}</span>
         <ChevronDown size={16} style={{ color: "var(--ink-400)", transform: open ? "rotate(180deg)" : "none", transition: "transform 0.15s", flexShrink: 0 }} />

--- a/components/man/Select.tsx
+++ b/components/man/Select.tsx
@@ -39,7 +39,7 @@ export function Select({
         type="button"
         disabled={disabled}
         onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center justify-between gap-2 rounded-[10px] border bg-white px-3.5 py-2.5 t-body outline-none transition-colors disabled:opacity-50"
+        className="flex w-full items-center justify-between gap-2 rounded-[8px] border bg-white px-3.5 py-2.5 t-body outline-none transition-colors disabled:opacity-50"
         style={{ borderColor: open ? "var(--moss-700)" : "var(--card-edge)", boxShadow: open ? "0 0 0 3px var(--moss-100)" : "none", color: selected ? "var(--ink-900)" : "var(--ink-400)" }}
       >
         <span className="truncate">{selected ? selected.label : placeholder}</span>
@@ -48,7 +48,7 @@ export function Select({
 
       {open && (
         <div
-          className="absolute z-50 mt-1.5 w-full rounded-[10px] border py-1"
+          className="absolute z-50 mt-1.5 w-full rounded-[8px] border py-1"
           style={{ background: "#ffffff", borderColor: "var(--card-edge)", boxShadow: "var(--shadow-lift)", maxHeight: 248, overflowY: "auto" }}
           role="listbox"
         >

--- a/components/man/Skeleton.tsx
+++ b/components/man/Skeleton.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+
+/* ── Skeleton: pulsing placeholder block ───────────────────────── */
+export function Skeleton({ className = "", style }: { className?: string; style?: React.CSSProperties }) {
+  return (
+    <div
+      className={`animate-pulse ${className}`}
+      style={{ background: "var(--paper-2)", borderRadius: 8, ...style }}
+    />
+  );
+}
+
+/* ── BusinessCardSkeleton: mirrors BusinessCard layout per variant ─ */
+export function BusinessCardSkeleton({ variant = "grid" }: { variant?: "grid" | "compact" }) {
+  if (variant === "compact") {
+    return (
+      <div className="flex gap-3 rounded-[12px] p-2.5" style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
+        <Skeleton style={{ width: 84, height: 84, borderRadius: 10, flexShrink: 0 }} />
+        <div className="flex min-w-0 flex-1 flex-col gap-2 py-1">
+          <Skeleton style={{ height: 14, width: "70%" }} />
+          <Skeleton style={{ height: 11, width: "45%" }} />
+          <Skeleton style={{ height: 11, width: "85%", marginTop: "auto" }} />
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-hidden rounded-[14px]" style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
+      <Skeleton style={{ width: "100%", aspectRatio: "16 / 9", borderRadius: 0 }} />
+      <div className="flex flex-col gap-2.5" style={{ padding: 16 }}>
+        <Skeleton style={{ height: 15, width: "65%" }} />
+        <Skeleton style={{ height: 12, width: "40%" }} />
+        <Skeleton style={{ height: 12, width: "100%" }} />
+        <Skeleton style={{ height: 12, width: "80%" }} />
+        <div className="mt-1 flex gap-1.5">
+          <Skeleton style={{ height: 18, width: 60, borderRadius: 999 }} />
+          <Skeleton style={{ height: 18, width: 72, borderRadius: 999 }} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/man/Skeleton.tsx
+++ b/components/man/Skeleton.tsx
@@ -15,7 +15,7 @@ export function BusinessCardSkeleton({ variant = "grid" }: { variant?: "grid" | 
   if (variant === "compact") {
     return (
       <div className="flex gap-3 rounded-[12px] p-2.5" style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
-        <Skeleton style={{ width: 84, height: 84, borderRadius: 10, flexShrink: 0 }} />
+        <Skeleton style={{ width: 84, height: 84, borderRadius: 8, flexShrink: 0 }} />
         <div className="flex min-w-0 flex-1 flex-col gap-2 py-1">
           <Skeleton style={{ height: 14, width: "70%" }} />
           <Skeleton style={{ height: 11, width: "45%" }} />
@@ -25,7 +25,7 @@ export function BusinessCardSkeleton({ variant = "grid" }: { variant?: "grid" | 
     );
   }
   return (
-    <div className="overflow-hidden rounded-[14px]" style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
+    <div className="overflow-hidden rounded-[12px]" style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
       <Skeleton style={{ width: "100%", aspectRatio: "16 / 9", borderRadius: 0 }} />
       <div className="flex flex-col gap-2.5" style={{ padding: 16 }}>
         <Skeleton style={{ height: 15, width: "65%" }} />

--- a/components/man/primitives.tsx
+++ b/components/man/primitives.tsx
@@ -57,7 +57,7 @@ export function PH({ title, sub, right }: { title: string; sub?: string; right?:
 /* ── Card ──────────────────────────────────────────────────────── */
 export function ManCard({ children, className = "", style, id }: { children: React.ReactNode; className?: string; style?: React.CSSProperties; id?: string }) {
   return (
-    <div id={id} className={className} style={{ background: "#ffffff", border: "1px solid var(--card-edge)", borderRadius: 14, boxShadow: "var(--shadow-soft)", ...style }}>
+    <div id={id} className={className} style={{ background: "#ffffff", border: "1px solid var(--card-edge)", borderRadius: 12, boxShadow: "var(--shadow-soft)", ...style }}>
       {children}
     </div>
   );

--- a/components/man/primitives.tsx
+++ b/components/man/primitives.tsx
@@ -92,7 +92,7 @@ export function Photo({ src, alt = "", seed = "x", h = 220, w, radius = 12, labe
 /* ── StatCard: KPI tile ────────────────────────────────────────── */
 export function StatCard({ label, value, sub, delta, deltaTone = "ok", Icon }: { label: string; value: string; sub?: string; delta?: string; deltaTone?: "ok" | "err"; Icon?: React.ComponentType<any> }) {
   return (
-    <ManCard style={{ padding: 18 }}>
+    <ManCard style={{ padding: 20 }}>
       <div className="flex items-start justify-between">
         <span className="t-eyebrow" style={{ color: "var(--ink-500)" }}>{label}</span>
         {Icon && <Icon size={16} style={{ color: "var(--ink-400)" }} />}

--- a/components/map/MapLibreMap.tsx
+++ b/components/map/MapLibreMap.tsx
@@ -313,7 +313,7 @@ export default function MapLibreMap({
                   }
                 }}
                 disabled={isLocating}
-                className="absolute top-24 right-2 z-10 bg-white p-2 rounded-lg shadow-md hover:bg-gray-50 disabled:opacity-50"
+                className="absolute top-24 right-2 z-10 bg-white p-2 rounded-lg shadow-[var(--shadow-rest)] hover:bg-gray-50 disabled:opacity-50"
                 title="Center on My Location"
               >
                 {isLocating ? (

--- a/components/map/SearchThisAreaButton.tsx
+++ b/components/map/SearchThisAreaButton.tsx
@@ -13,7 +13,7 @@ export function SearchThisAreaButton({ onClick, isLoading }: SearchThisAreaButto
     <Button
       onClick={onClick}
       disabled={isLoading}
-      className="shadow-lg"
+      className="shadow-[var(--shadow-lift)]"
     >
       {isLoading ? (
         <>

--- a/components/map/UserLocationMarker.tsx
+++ b/components/map/UserLocationMarker.tsx
@@ -28,7 +28,7 @@ export function UserLocationMarker({ latitude, longitude }: UserLocationMarkerPr
           <div className="absolute inset-0 w-6 h-6 bg-blue-500 rounded-full opacity-30 animate-ping" />
           {/* Solid center dot */}
           <div
-            className="relative w-4 h-4 bg-blue-500 border-2 border-white rounded-full shadow-lg"
+            className="relative w-4 h-4 bg-blue-500 border-2 border-white rounded-full shadow-[var(--shadow-lift)]"
             style={{ margin: '4px' }}
           />
         </div>

--- a/components/role-switcher.tsx
+++ b/components/role-switcher.tsx
@@ -28,14 +28,14 @@ export function RoleSwitcher() {
         <Button
           onClick={() => setIsOpen(true)}
           variant="outline"
-          className="shadow-lg bg-yellow-100 border-yellow-300 hover:bg-yellow-200"
+          className="shadow-[var(--shadow-lift)] bg-yellow-100 border-yellow-300 hover:bg-yellow-200"
         >
           🎭 Mock Mode ({session?.user.role || "None"})
         </Button>
       )}
 
       {isOpen && (
-        <Card className="shadow-xl w-80">
+        <Card className="shadow-[var(--shadow-lift)] w-80">
           <CardHeader className="bg-yellow-50">
             <div className="flex items-center justify-between">
               <CardTitle className="text-sm">🎭 Role Switcher (Mock Mode)</CardTitle>

--- a/components/search/FilterSheet.tsx
+++ b/components/search/FilterSheet.tsx
@@ -38,7 +38,7 @@ export function FilterSheet({
         style={{ background: "var(--paper)", transform: open ? "translateX(0)" : "translateX(100%)" }}>
         <div className="flex items-center justify-between px-5 py-4" style={{ borderBottom: "1px solid var(--card-edge)", background: "var(--card)" }}>
           <div className="flex items-center gap-2"><SlidersHorizontal size={18} style={{ color: "var(--moss-700)" }} /><span className="t-h4" style={{ color: "var(--ink-900)" }}>Filters</span>{activeCount > 0 && <ManTag tone="moss">{activeCount}</ManTag>}</div>
-          <button onClick={onClose} className="rounded-lg p-1.5 hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-500)" }}><X size={18} /></button>
+          <button onClick={onClose} className="man-focus rounded-lg p-1.5 hover:bg-[var(--paper-2)]" style={{ color: "var(--ink-500)" }}><X size={18} /></button>
         </div>
 
         <div className="flex-1 overflow-auto px-5">

--- a/components/search/ViewToggle.tsx
+++ b/components/search/ViewToggle.tsx
@@ -23,7 +23,7 @@ export function ViewToggle({ value, onChange }: ViewToggleProps) {
           <button
             key={m.key}
             onClick={() => onChange(m.key)}
-            className="flex items-center gap-1.5 px-3 py-1.5 t-label transition-colors"
+            className="man-focus flex items-center gap-1.5 px-3 py-1.5 t-label transition-colors"
             style={on ? { background: "var(--moss-700)", color: "var(--bone)" } : { background: "#ffffff", color: "var(--ink-500)" }}
           >
             <m.Icon className="h-4 w-4" />

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -19,7 +19,7 @@ export function SiteFooter() {
         </div>
         {cols.map(([h, items]) => (
           <div key={h}>
-            <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 10 }}>{h}</div>
+            <div className="t-eyebrow" style={{ color: "var(--ink-500)", marginBottom: 8 }}>{h}</div>
             {items.map(([label, href]) => (
               <div key={label} className="t-body-sm" style={{ color: "var(--ink-700)", padding: "4px 0" }}>
                 <Link href={href} className="hover:underline">{label}</Link>
@@ -28,7 +28,7 @@ export function SiteFooter() {
           </div>
         ))}
       </div>
-      <div className="flex justify-between" style={{ paddingTop: 18, borderTop: "1px solid var(--card-edge)" }}>
+      <div className="flex justify-between" style={{ paddingTop: 20, borderTop: "1px solid var(--card-edge)" }}>
         <span className="t-body-xs" style={{ color: "var(--ink-500)" }}>© 2026 Manaakhah · Sacramento, CA</span>
         <span className="t-body-xs" style={{ color: "var(--ink-500)" }}>English (US) · USD</span>
       </div>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "man-focus inline-flex items-center justify-center whitespace-nowrap rounded-[12px] text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50",
+  "man-focus inline-flex items-center justify-center whitespace-nowrap rounded-[8px] text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
@@ -19,8 +19,8 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-[12px] px-3",
-        lg: "h-11 rounded-[12px] px-8",
+        sm: "h-9 rounded-[8px] px-3",
+        lg: "h-11 rounded-[8px] px-8",
         icon: "h-10 w-10",
       },
     },

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-[8px] text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "man-focus inline-flex items-center justify-center whitespace-nowrap rounded-[12px] text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
@@ -19,8 +19,8 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-[8px] px-3",
-        lg: "h-11 rounded-[8px] px-8",
+        sm: "h-9 rounded-[12px] px-3",
+        lg: "h-11 rounded-[12px] px-8",
         icon: "h-10 w-10",
       },
     },

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -8,7 +8,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-lg border bg-card text-card-foreground shadow-[var(--shadow-soft)]",
       className
     )}
     {...props}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-lift)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-rest)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "man-field flex h-10 w-full px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -9,7 +9,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     return (
       <select
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "man-field flex h-10 w-full px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -42,7 +42,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:ring-ring inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:ring-ring inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-[var(--shadow-soft)]",
         className,
       )}
       {...props}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "man-field flex min-h-[80px] w-full px-3 py-2 text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/docs/DESIGN_CONVENTIONS.md
+++ b/docs/DESIGN_CONVENTIONS.md
@@ -1,0 +1,53 @@
+# Manaakhah Design Conventions
+
+The single reference for how UI is built in this app. Follow it so new pages don't reintroduce the inconsistency ("vibe-coded") drift. `_legacy/` is exempt (archived).
+
+> Background audits live in `docs/superpowers/specs/2026-06-16-*`.
+
+## 1. Component layer — use the design system, not raw shadcn
+- Build from `components/man/primitives.tsx` (`ManCard`, `Tag`, `Rating`, `Avatar`, `StatCard`, `Seal`, `PH`, `Divider`) and the shared components: `components/business/BusinessCard.tsx`, `components/man/EmptyState.tsx`, `components/man/Skeleton.tsx`, `components/man/Select.tsx`, `components/man/Choice.tsx`, `components/man/DatePicker.tsx`.
+- shadcn primitives (`ui/Button`, `ui/Input`, `ui/Textarea`, `ui/Select`) are the skinned base — they already carry the conventions below. Use them; don't hand-roll a second card/field/button vocabulary on a page.
+- If you find yourself copy-pasting a control's markup a second time, extract a shared component instead.
+
+## 2. Styling method (the one rule that prevents drift)
+- **Layout** (flex, grid, spacing, sizing) → **Tailwind utility classes**.
+- **Typography** → the `t-*` classes (`t-h1`…`t-h4`, `t-body`, `t-body-sm`, `t-label`, `t-eyebrow`, …).
+- **Color** → CSS tokens via `style={{ color: "var(--ink-700)" }}` etc. (the established house pattern). Do **not** use shadcn semantic grays like `text-muted-foreground` in app pages — use `var(--ink-*)`.
+- **Inline `style={{}}`** is for token colors and genuinely dynamic/computed values only — not for layout you could express with a utility.
+
+## 3. Color tokens
+`--ink-900/700/500/400/300` (text), `--moss-900…50` (brand), `--clay-*` (accent), `--paper / --paper-2 / --paper-3 / --card-edge / --hairline` (surfaces), `--bone`, `--ok/warn/err-500`. Never use raw hex except `#ffffff` for control/card fills.
+
+## 4. Corner radius — 4px grid (see `2026-06-16-radius-scale.md`)
+- **4px** — checkboxes, tiny chips, focus-halo corners
+- **8px** — controls: **buttons + inputs/fields**, icon buttons, search containers
+- **12px** — cards, panels, dropdowns, large tiles, upload drop-zones
+- **full** — pills, toggles, avatars
+
+Tailwind: `rounded-sm`=8, `rounded-md`/`rounded-lg`=12. No off-grid literals (no `rounded-[10px]`/`[14px]`/etc.).
+
+## 5. Spacing — 4px scale (see `2026-06-16-spacing-scale.md`)
+- Scale: `4 · 8 · 12 · 16 · 20 · 24 · 28 · 32 · 40 · 48`. Standard card/panel inner padding = **20**.
+- Inline `padding`/`margin`/`gap` numbers must be on the scale (≤2px optical nudges allowed). Tailwind's 2px half-steps (`gap-1.5`, `py-2.5`, …) are an accepted sub-grid and may be used.
+
+## 6. Focus / selected state — one moss halo everywhere
+- Inputs/fields → class `man-field` (border + 8px radius + moss-700 border & `0 0 0 3px var(--moss-100)` halo on focus).
+- Input-inside-a-bordered-container (search bars) → `man-field-wrap` on the container (halo on `:focus-within`). ⚠️ Never put an inline `borderColor` on a `man-field`/`man-field-wrap` element — it overrides the focus rule.
+- Buttons & other clickable controls → class `man-focus` (halo on `:focus-visible`, follows the element's radius).
+- `man/Choice` checkbox/radio → `man-focusable`.
+- The shared `Button` already includes `man-focus`.
+
+## 7. Pills / segmented toggles
+`rounded-full`, `px-3 py-1.5` (compact: `px-2.5 py-1`). **Active:** `var(--moss-700)` bg + `var(--bone)` text. **Inactive:** `var(--paper-2)` bg + `var(--ink-700)` text. Add `man-focus`.
+
+## 8. Elevation — 3 shadow tokens only (see P1-4)
+- `--shadow-soft` — resting cards (the `ManCard`/`Card` default).
+- `--shadow-rest` — raised/interactive elements (a control floating over media, hover on list rows).
+- `--shadow-lift` — overlays: dropdowns, popovers, floating buttons, card hover.
+
+Use `shadow-[var(--shadow-soft|rest|lift)]` (or inline `boxShadow`). Do **not** use Tailwind `shadow-sm/md/lg/xl`.
+
+## 9. Icons & states
+- Icons: **lucide-react only**. Never emoji as UI/iconography.
+- Loading → `Skeleton` / `BusinessCardSkeleton` (never spinners).
+- Empty → the shared `EmptyState` (lucide icon + title + description + optional action).

--- a/docs/superpowers/plans/2026-06-16-design-p0-search-polish.md
+++ b/docs/superpowers/plans/2026-06-16-design-p0-search-polish.md
@@ -1,0 +1,650 @@
+# Design P0 — Search Page Polish & Shared Components Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the search/results page up to the visual standard of the homepage by extracting shared `BusinessCard`, `EmptyState`, and `Skeleton` components and replacing the page's un-skinned shadcn defaults, emoji, and spinners.
+
+**Architecture:** Add three reusable, token-styled components to the existing `man`/`business` component layer, then refactor `app/search/page.tsx` to consume them. The card is presentational (state stays in the page); loading uses skeletons that mirror the results grid; the no-results state uses a shared `EmptyState` with a lucide icon instead of an emoji.
+
+**Tech Stack:** Next.js (App Router), React, TypeScript (strict), Tailwind CSS, `lucide-react`, the Manaakhah token system in `app/globals.css`.
+
+**Verification model:** This codebase has **no test framework** (no Jest/Vitest, no test script). Adding one is out of scope for P0. Each task is verified by TypeScript typecheck (`npx tsc --noEmit`) + production build (`npm run build`), and the final task is a visual verification pass. Components are written to be pure/presentational so they're easy to reason about without a harness.
+
+**Scope:** This plan covers only the **P0** items from `docs/superpowers/specs/2026-06-16-design-polish-consistency-audit.md` (P0-1 through P0-6). P1/P2 are separate plans.
+
+**Source of truth for current card markup:** `app/search/page.tsx`, function `renderBusinessCard` (~lines 209-329). The new `BusinessCard` is a faithful extraction of that markup, parameterized by `variant`.
+
+---
+
+## File Structure
+
+- **Create** `components/man/Skeleton.tsx` — `Skeleton` base block + `BusinessCardSkeleton` (grid/compact). Loading placeholders. (P0-5)
+- **Create** `components/man/EmptyState.tsx` — shared empty state: icon + title + description + optional action. (P0-3, P0-4)
+- **Create** `components/business/BusinessCard.tsx` — presentational business card with `variant="grid" | "compact"`. (P0-1)
+- **Modify** `app/search/page.tsx` — consume `BusinessCard`, `EmptyState`, `BusinessCardSkeleton`; remove dead `Card`/`CardContent` import; replace `text-muted-foreground`/emoji/spinners. (P0-2, P0-3, P0-5, P0-6)
+
+The `Business` type is imported from `hooks/useMapSearch.ts` (`export interface Business`).
+
+---
+
+## Task 1: Skeleton primitives
+
+**Files:**
+- Create: `components/man/Skeleton.tsx`
+
+- [ ] **Step 1: Create the Skeleton component file**
+
+Create `components/man/Skeleton.tsx` with this exact content:
+
+```tsx
+import * as React from "react";
+
+/* ── Skeleton: pulsing placeholder block ───────────────────────── */
+export function Skeleton({ className = "", style }: { className?: string; style?: React.CSSProperties }) {
+  return (
+    <div
+      className={`animate-pulse ${className}`}
+      style={{ background: "var(--paper-2)", borderRadius: 8, ...style }}
+    />
+  );
+}
+
+/* ── BusinessCardSkeleton: mirrors BusinessCard layout per variant ─ */
+export function BusinessCardSkeleton({ variant = "grid" }: { variant?: "grid" | "compact" }) {
+  if (variant === "compact") {
+    return (
+      <div className="flex gap-3 rounded-[12px] p-2.5" style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
+        <Skeleton style={{ width: 84, height: 84, borderRadius: 10, flexShrink: 0 }} />
+        <div className="flex min-w-0 flex-1 flex-col gap-2 py-1">
+          <Skeleton style={{ height: 14, width: "70%" }} />
+          <Skeleton style={{ height: 11, width: "45%" }} />
+          <Skeleton style={{ height: 11, width: "85%", marginTop: "auto" }} />
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-hidden rounded-[14px]" style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
+      <Skeleton style={{ width: "100%", aspectRatio: "16 / 9", borderRadius: 0 }} />
+      <div className="flex flex-col gap-2.5" style={{ padding: 16 }}>
+        <Skeleton style={{ height: 15, width: "65%" }} />
+        <Skeleton style={{ height: 12, width: "40%" }} />
+        <Skeleton style={{ height: 12, width: "100%" }} />
+        <Skeleton style={{ height: 12, width: "80%" }} />
+        <div className="mt-1 flex gap-1.5">
+          <Skeleton style={{ height: 18, width: 60, borderRadius: 999 }} />
+          <Skeleton style={{ height: 18, width: 72, borderRadius: 999 }} />
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit -p tsconfig.json`
+Expected: no errors (ignore any "npm notice" lines).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/man/Skeleton.tsx
+git commit -m "feat: add Skeleton and BusinessCardSkeleton primitives"
+```
+
+---
+
+## Task 2: EmptyState component
+
+**Files:**
+- Create: `components/man/EmptyState.tsx`
+
+- [ ] **Step 1: Create the EmptyState component file**
+
+Create `components/man/EmptyState.tsx` with this exact content:
+
+```tsx
+import * as React from "react";
+import { type LucideIcon } from "lucide-react";
+
+/* ── EmptyState: icon + title + description + optional action ───── */
+export function EmptyState({
+  Icon,
+  title,
+  description,
+  action,
+}: {
+  Icon: LucideIcon;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center px-6 py-16 text-center">
+      <span className="flex h-14 w-14 items-center justify-center rounded-full" style={{ background: "var(--paper-2)" }}>
+        <Icon size={24} style={{ color: "var(--ink-400)" }} />
+      </span>
+      <h3 className="t-h4" style={{ color: "var(--ink-900)", marginTop: 16 }}>{title}</h3>
+      {description && (
+        <p className="t-body-sm" style={{ color: "var(--ink-500)", marginTop: 6, maxWidth: 360 }}>{description}</p>
+      )}
+      {action && <div className="mt-5">{action}</div>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit -p tsconfig.json`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/man/EmptyState.tsx
+git commit -m "feat: add shared EmptyState component"
+```
+
+---
+
+## Task 3: BusinessCard component
+
+**Files:**
+- Create: `components/business/BusinessCard.tsx`
+
+This is a faithful extraction of `renderBusinessCard` from `app/search/page.tsx`, parameterized by `variant`. State (favorites, recently-viewed) stays in the parent; the card receives `isFavorite`, `onToggleFavorite`, and `onView`.
+
+- [ ] **Step 1: Create the BusinessCard component file**
+
+Create `components/business/BusinessCard.tsx` with this exact content:
+
+```tsx
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { Heart, Star, Store } from "lucide-react";
+import { Tag } from "@/components/man/primitives";
+import { BUSINESS_CATEGORIES, BUSINESS_TAGS, PRICE_RANGES } from "@/lib/constants";
+import type { Business } from "@/hooks/useMapSearch";
+
+function resolveImage(b: Business): string | undefined {
+  const cover = (b as any).coverImage;
+  if (cover) return cover;
+  const first = (b as any).photos?.[0];
+  if (!first) return undefined;
+  return typeof first === "string" ? first : first.url;
+}
+
+export function BusinessCard({
+  business,
+  variant = "grid",
+  isFavorite = false,
+  onToggleFavorite,
+  onView,
+}: {
+  business: Business;
+  variant?: "grid" | "compact";
+  isFavorite?: boolean;
+  onToggleFavorite?: (e: React.MouseEvent) => void;
+  onView?: () => void;
+}) {
+  const img = resolveImage(business);
+  const cat = BUSINESS_CATEGORIES.find((c) => c.value === business.category)?.label;
+  const price = PRICE_RANGES.find((p) => p.value === business.priceRange)?.label;
+  const knownTags = (business.tags || [])
+    .map((t) => BUSINESS_TAGS.find((bt) => bt.value === t.tag))
+    .filter(Boolean) as { value: string; label: string }[];
+
+  // Compact = short horizontal row (used in split view alongside the map)
+  if (variant === "compact") {
+    return (
+      <Link href={`/business/${business.id}`} onClick={onView}>
+        <div className="flex gap-3 overflow-hidden rounded-[12px] p-2.5 transition-shadow hover:shadow-[var(--shadow-rest)]"
+          style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
+          <div className="relative h-[84px] w-[84px] flex-shrink-0 overflow-hidden rounded-[10px]">
+            {img ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={img} alt={business.name} loading="lazy" className="h-full w-full object-cover" />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center" style={{ background: "linear-gradient(135deg, var(--moss-100), var(--moss-200))" }}>
+                <Store size={20} style={{ color: "var(--moss-700)" }} />
+              </div>
+            )}
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col">
+            <div className="flex items-start justify-between gap-2">
+              <h3 className="t-label line-clamp-1" style={{ color: "var(--ink-900)" }}>{business.name}</h3>
+              <button onClick={onToggleFavorite} aria-label="Save" className="-mr-0.5 flex-shrink-0">
+                <Heart size={15} fill={isFavorite ? "var(--clay-500)" : "none"} stroke={isFavorite ? "var(--clay-500)" : "var(--ink-400)"} />
+              </button>
+            </div>
+            <div className="mt-0.5 flex flex-wrap items-center gap-x-2 t-body-xs" style={{ color: "var(--ink-500)" }}>
+              {business.averageRating > 0 && (
+                <span className="inline-flex items-center gap-1" style={{ color: "var(--ink-700)" }}>
+                  <Star size={12} fill="var(--clay-500)" stroke="none" />
+                  <span style={{ fontWeight: 600 }}>{business.averageRating.toFixed(1)}</span>
+                  <span style={{ color: "var(--ink-400)" }}>({business.reviewCount})</span>
+                </span>
+              )}
+              {cat && <span>{cat}</span>}
+              {price && <span>· {price}</span>}
+            </div>
+            <p className="mt-auto pt-1 t-body-xs line-clamp-1" style={{ color: "var(--ink-500)" }}>
+              {[business.address, business.city].filter(Boolean).join(", ")}
+              {business.distance !== undefined && ` · ${business.distance.toFixed(1)} mi`}
+            </p>
+          </div>
+        </div>
+      </Link>
+    );
+  }
+
+  // Grid = vertical card (default)
+  return (
+    <Link href={`/business/${business.id}`} onClick={onView}>
+      <div className="h-full overflow-hidden rounded-[14px] transition-shadow hover:shadow-[var(--shadow-lift)]"
+        style={{ background: "#ffffff", border: "1px solid var(--card-edge)" }}>
+        <div className="relative">
+          {img ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={img} alt={business.name} loading="lazy" className="aspect-video w-full object-cover" />
+          ) : (
+            <div className="aspect-video flex items-center justify-center"
+              style={{ background: "linear-gradient(135deg, var(--moss-100), var(--moss-200))" }}>
+              <Store size={26} style={{ color: "var(--moss-700)" }} />
+            </div>
+          )}
+
+          <button onClick={onToggleFavorite} aria-label="Save"
+            className="absolute right-2.5 top-2.5 flex h-8 w-8 items-center justify-center rounded-full shadow-md transition-transform hover:scale-110"
+            style={{ background: "#ffffff" }}>
+            <Heart size={15} fill={isFavorite ? "var(--clay-500)" : "none"} stroke={isFavorite ? "var(--clay-500)" : "var(--ink-500)"} />
+          </button>
+
+          {price && (
+            <div className="absolute bottom-2.5 left-2.5 rounded-md px-2 py-0.5"
+              style={{ background: "rgba(17,50,30,0.78)", color: "var(--bone)", fontSize: 11 }}>{price}</div>
+          )}
+        </div>
+
+        <div style={{ padding: 16 }}>
+          <div className="flex items-start justify-between gap-2">
+            <h3 className="t-label line-clamp-1" style={{ color: "var(--ink-900)" }}>{business.name}</h3>
+            {business.distance !== undefined && (
+              <span className="t-body-xs whitespace-nowrap" style={{ color: "var(--ink-500)" }}>{business.distance.toFixed(1)} mi</span>
+            )}
+          </div>
+
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 t-body-sm" style={{ color: "var(--ink-500)" }}>
+            {business.averageRating > 0 && (
+              <span className="inline-flex items-center gap-1" style={{ color: "var(--ink-700)" }}>
+                <Star size={13} fill="var(--clay-500)" stroke="none" />
+                <span style={{ fontWeight: 600 }}>{business.averageRating.toFixed(1)}</span>
+                <span style={{ color: "var(--ink-400)" }}>({business.reviewCount})</span>
+              </span>
+            )}
+            {cat && <span>{cat}</span>}
+          </div>
+
+          {business.description && (
+            <p className="mt-2 t-body-sm line-clamp-2" style={{ color: "var(--ink-500)" }}>{business.description}</p>
+          )}
+
+          <p className="mt-2 t-body-sm line-clamp-1" style={{ color: "var(--ink-500)" }}>{[business.address, business.city].filter(Boolean).join(", ")}</p>
+
+          {knownTags.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {knownTags.slice(0, 3).map((t) => (
+                <Tag key={t.value} tone="moss">{t.label}</Tag>
+              ))}
+              {knownTags.length > 3 && <Tag>+{knownTags.length - 3}</Tag>}
+            </div>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit -p tsconfig.json`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/business/BusinessCard.tsx
+git commit -m "feat: extract shared BusinessCard component"
+```
+
+---
+
+## Task 4: Migrate search results to BusinessCard
+
+**Files:**
+- Modify: `app/search/page.tsx`
+
+This task swaps the inline `renderBusinessCard` for the new component, removes the dead `Card`/`CardContent` import, fixes the results-count gray (P0-6), and deletes now-unused imports.
+
+- [ ] **Step 1: Add the BusinessCard import**
+
+In `app/search/page.tsx`, find the import of `FilterRail`:
+
+```tsx
+import { FilterRail } from "@/components/search/FilterRail";
+```
+
+Add immediately after it:
+
+```tsx
+import { BusinessCard } from "@/components/business/BusinessCard";
+```
+
+- [ ] **Step 2: Remove the dead shadcn Card import**
+
+Find and delete this line (it is imported but never used in JSX):
+
+```tsx
+import { Card, CardContent } from "@/components/ui/card";
+```
+
+- [ ] **Step 3: Delete the inline `renderBusinessCard` function**
+
+Delete the entire `renderBusinessCard` function — from the line:
+
+```tsx
+  // Render business card
+  const renderBusinessCard = (business: Business, compact: boolean = false) => {
+```
+
+through its closing `};` (the block that ends just before `return (` of the component's main JSX, i.e. the line `    );\n  };` that precedes `  return (\n    <div className="min-h-screen"`). Remove the leading comment line too.
+
+- [ ] **Step 4: Replace the split-view (compact) list mapping**
+
+Find:
+
+```tsx
+                      {sortedBusinesses.map((business) => renderBusinessCard(business, true))}
+```
+
+Replace with:
+
+```tsx
+                      {sortedBusinesses.map((business) => (
+                        <BusinessCard
+                          key={business.id}
+                          business={business}
+                          variant="compact"
+                          isFavorite={favorites.includes(business.id)}
+                          onToggleFavorite={(e) => toggleFavorite(business.id, e)}
+                          onView={() => addToRecentlyViewed(business.id)}
+                        />
+                      ))}
+```
+
+- [ ] **Step 5: Replace the grid mapping**
+
+Find:
+
+```tsx
+                    {sortedBusinesses.map((business) => renderBusinessCard(business))}
+```
+
+Replace with:
+
+```tsx
+                    {sortedBusinesses.map((business) => (
+                      <BusinessCard
+                        key={business.id}
+                        business={business}
+                        isFavorite={favorites.includes(business.id)}
+                        onToggleFavorite={(e) => toggleFavorite(business.id, e)}
+                        onView={() => addToRecentlyViewed(business.id)}
+                      />
+                    ))}
+```
+
+- [ ] **Step 6: Fix the results-count gray (P0-6)**
+
+Find:
+
+```tsx
+                  <p className="text-muted-foreground">
+                    Found <strong>{sortedBusinesses.length}</strong> businesses
+                    {userLocation && ` within ${filters.distance} miles`}
+                  </p>
+```
+
+Replace with:
+
+```tsx
+                  <p className="t-body-sm" style={{ color: "var(--ink-500)" }}>
+                    Found <strong style={{ color: "var(--ink-900)" }}>{sortedBusinesses.length}</strong> businesses
+                    {userLocation && ` within ${filters.distance} miles`}
+                  </p>
+```
+
+- [ ] **Step 7: Remove now-unused imports**
+
+These symbols were only used by the deleted `renderBusinessCard`. Remove them:
+
+- From the `lucide-react` import on the search page, remove `Heart`, `Star`, and `Store` (keep `Bookmark, MessageCircle, SlidersHorizontal, ChevronDown, X`).
+- Remove the `import { Tag } from "@/components/man/primitives";` line.
+- From the `@/lib/constants` import, remove `BUSINESS_CATEGORIES`, `BUSINESS_TAGS`, and `PRICE_RANGES` (keep `DISTANCE_OPTIONS`, `SORT_OPTIONS`, `DEFAULT_LOCATION`).
+
+> Note: `strict` is on but `noUnusedLocals` is **not**, so a missed unused import will not fail the build — but remove them for cleanliness. If typecheck/build passes, you're fine.
+
+- [ ] **Step 8: Typecheck**
+
+Run: `npx tsc --noEmit -p tsconfig.json`
+Expected: no errors. If you see "Cannot find name 'renderBusinessCard'", you missed a call site — search the file for `renderBusinessCard` and convert it to a `<BusinessCard>` like Steps 4-5.
+
+- [ ] **Step 9: Production build**
+
+Run: `npm run build`
+Expected: "✓ Compiled successfully" and all pages generate.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add app/search/page.tsx
+git commit -m "refactor: use shared BusinessCard on search; drop dead shadcn Card import"
+```
+
+---
+
+## Task 5: Replace search loading & empty states (kill emoji + spinners)
+
+**Files:**
+- Modify: `app/search/page.tsx`
+
+- [ ] **Step 1: Add imports for the new states**
+
+After the `BusinessCard` import added in Task 4, add:
+
+```tsx
+import { BusinessCardSkeleton } from "@/components/man/Skeleton";
+import { EmptyState } from "@/components/man/EmptyState";
+```
+
+Then add `Search` to the existing `lucide-react` import on the search page (it is used for the empty-state icon). The import should include `Search` alongside the others, e.g. `import { Bookmark, MessageCircle, SlidersHorizontal, ChevronDown, X, Search } from "lucide-react";`.
+
+- [ ] **Step 2: Replace the results loading spinner with skeletons**
+
+Find:
+
+```tsx
+            {isLoading ? (
+              <div className="text-center py-12">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+                <p className="text-muted-foreground">Finding businesses near you...</p>
+              </div>
+            ) : sortedBusinesses.length === 0 ? (
+```
+
+Replace with:
+
+```tsx
+            {isLoading ? (
+              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <BusinessCardSkeleton key={i} />
+                ))}
+              </div>
+            ) : sortedBusinesses.length === 0 ? (
+```
+
+- [ ] **Step 3: Replace the emoji empty state with EmptyState (P0-3)**
+
+Find:
+
+```tsx
+              <div className="text-center py-12">
+                <div className="text-6xl mb-4">🔍</div>
+                <p className="text-muted-foreground mb-4">No businesses found</p>
+                <p className="text-sm text-muted-foreground mb-4">
+                  Try adjusting your search filters or expanding your search radius
+                </p>
+                <Button variant="outline" onClick={clearFilters}>
+                  Clear Filters
+                </Button>
+              </div>
+```
+
+Replace with:
+
+```tsx
+              <EmptyState
+                Icon={Search}
+                title="No businesses found"
+                description="Try adjusting your search filters or expanding your search radius."
+                action={
+                  <Button variant="outline" onClick={clearFilters}>
+                    Clear Filters
+                  </Button>
+                }
+              />
+```
+
+- [ ] **Step 4: Replace the Suspense fallback spinner with skeletons**
+
+Find the `SearchPage` default export fallback:
+
+```tsx
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--moss-700)] mx-auto"></div>
+          <p className="mt-4 text-muted-foreground">Loading search...</p>
+        </div>
+      </div>
+    }>
+```
+
+Replace with:
+
+```tsx
+    <Suspense fallback={
+      <div className="min-h-screen" style={{ background: "var(--paper)" }}>
+        <div className="container mx-auto max-w-6xl py-8 px-4">
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <BusinessCardSkeleton key={i} />
+            ))}
+          </div>
+        </div>
+      </div>
+    }>
+```
+
+> Note: `BusinessCardSkeleton` and the import added in Step 1 are module-scope, so they're usable in the `SearchPage` export as well as `SearchContent`.
+
+- [ ] **Step 5: Replace the map loading placeholder spinner text**
+
+Find the dynamic-import loading placeholder near the top of the file:
+
+```tsx
+  loading: () => (
+    <div className="h-[600px] rounded-lg flex items-center justify-center" style={{ background: "var(--paper-2)" }}>
+      <p className="text-muted-foreground">Loading map...</p>
+    </div>
+  ),
+```
+
+Replace with:
+
+```tsx
+  loading: () => (
+    <div className="h-[600px] rounded-lg flex items-center justify-center" style={{ background: "var(--paper-2)" }}>
+      <p className="t-body-sm" style={{ color: "var(--ink-500)" }}>Loading map…</p>
+    </div>
+  ),
+```
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npx tsc --noEmit -p tsconfig.json`
+Expected: no errors.
+
+- [ ] **Step 7: Verify no stray emoji/spinner/muted-foreground remain on the page**
+
+Run: `grep -nE "🔍|animate-spin|text-muted-foreground|text-6xl" app/search/page.tsx`
+Expected: **no output** (all replaced).
+
+- [ ] **Step 8: Production build**
+
+Run: `npm run build`
+Expected: "✓ Compiled successfully" and all pages generate.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/search/page.tsx
+git commit -m "refactor: skeleton loaders + EmptyState on search; remove emoji and spinners"
+```
+
+---
+
+## Task 6: Visual verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `npm run dev`
+Open `http://localhost:3000/search`.
+
+- [ ] **Step 2: Verify the result grid**
+
+Confirm: business cards render identically to before (image, favorite heart, price badge, name, rating, category, description, tags). Toggling the heart still works. Clicking a card navigates to `/business/[id]`.
+
+- [ ] **Step 3: Verify the split view**
+
+Switch the view toggle to "split". Confirm the compact rows render correctly beside the map and the map still loads.
+
+- [ ] **Step 4: Verify the empty state**
+
+Apply a filter that yields zero results (e.g. a nonsense search term). Confirm the empty state shows a **Search icon** (not the 🔍 emoji), the title/description, and a working "Clear Filters" button.
+
+- [ ] **Step 5: Verify loading skeletons**
+
+Reload `/search` and watch the initial load — confirm skeleton cards appear (pulsing placeholders in the grid shape) instead of a spinner.
+
+- [ ] **Step 6: Confirm visual consistency**
+
+Compare the search page side by side with the homepage (`/`). Confirm the cards, grays, and spacing now read as the same design language.
+
+- [ ] **Step 7: Stop the dev server** (Ctrl-C).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** P0-1 (BusinessCard, Task 3) ✓; P0-2 (migrate search off shadcn, Task 4) ✓; P0-3 (kill emoji, Task 5 Step 3) ✓; P0-4 (EmptyState, Task 2) ✓; P0-5 (skeletons, Tasks 1 + 5) ✓; P0-6 (one color vocabulary, Task 4 Step 6 + Task 5 replacements + grep gate Task 5 Step 7) ✓.
+- **Out of scope (P1/P2):** the hero vs. search input divergence, the app-wide spacing scale, button radius, and the remaining-pages sweep are intentionally deferred to later plans.
+- **Type consistency:** `BusinessCard` props (`business`, `variant`, `isFavorite`, `onToggleFavorite`, `onView`) are used identically at all three call sites; `Business` is imported from `hooks/useMapSearch`; `BusinessCardSkeleton` `variant` matches `BusinessCard` `variant` ("grid" | "compact").

--- a/docs/superpowers/specs/2026-06-16-button-control-consistency.md
+++ b/docs/superpowers/specs/2026-06-16-button-control-consistency.md
@@ -1,0 +1,83 @@
+# Button & Interactive-Control Consistency
+
+**Date:** 2026-06-16
+**Parent:** Extends `2026-06-16-design-polish-consistency-audit.md` (P1-2 button radius + the "one focus treatment" work) and follows `2026-06-16-form-control-consistency-audit.md`.
+**Goal:** One coherent treatment for buttons and clickable controls — radius, focus state, and pill active color.
+
+---
+
+## 1. Problems found
+
+- **Radius drift:** shared `Button` = `8px`, form fields = `10px`, dropdowns = `12px`, cards = `14px`, checkboxes = `5px`, pills = full. Buttons are out of step.
+- **Focus-state crisis:** only the shadcn `Button` (offset ring) and `man/Select`+`man/DatePicker` (halo) have focus states. ~14 hand-rolled control types have **none**: filter pills, segmented toggle (`ViewToggle`), underline tabs, toggle switches, icon buttons, dashed upload buttons, header nav links, dropdown menu items, option-selection cards, stepper circles, hero save/share pills.
+- **Filter pills disagree:** active state is `moss-700` in most places but `ink-900` in `app/admin/reviews/page.tsx`; radius is `rounded-full` everywhere except the search `ViewToggle` (`rounded-lg`).
+- **Mixed focus languages:** `Button` uses `ring-2 + ring-offset-2`; the man controls use the `moss-100` halo (no offset). Two different focus looks.
+
+---
+
+## 2. Convention (approved)
+
+### Radius system
+- **Buttons: 12px** (approved) — all variants and sizes.
+- Inputs / form controls: **10px** (already standardized).
+- Cards / containers: **14px**.
+- Pills / toggles / circular: **full**.
+- Checkbox: 5px, radio: full (unchanged).
+
+### One focus treatment everywhere
+A single shared utility, `.man-focus`, applied to every interactive control:
+
+```css
+.man-focus:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--moss-100);
+}
+```
+
+No radius override — the halo follows each element's own radius (pill-shaped on pills, rounded on buttons). This matches the input/field focus language (moss-100 halo) so the whole app shares one focus look. The shared `Button` is migrated from its `ring-2 ring-offset-2` to this halo.
+
+### Pill / segmented active state
+All filter/segmented pills standardize to:
+- `rounded-full px-3 py-1.5` (compact variants may use `px-2.5 py-1`)
+- **Active:** `background: var(--moss-700)`, `color: var(--bone)`
+- **Inactive:** `background: var(--paper-2)`, `color: var(--ink-700)` (or a `card` bg + `card-edge` border where that pattern already exists)
+- `man-focus` for keyboard focus
+- The search `ViewToggle` keeps its segmented container but its active segment uses the same `moss-700`/`bone`.
+
+---
+
+## 3. Target list (batch fix)
+
+### Pass 1 — Foundation
+- `components/ui/button.tsx`: `rounded-[8px]` → `rounded-[12px]` (base + `sm` + `lg`); replace `focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2` with the `man-focus` halo (add `man-focus` to the base classes, drop the ring classes).
+- `app/globals.css`: add `.man-focus:focus-visible { outline:none; box-shadow:0 0 0 3px var(--moss-100); }`.
+
+### Pass 2 — Pills & segmented controls (add `man-focus`, unify active color to moss)
+- `components/search/ViewToggle.tsx`
+- `app/admin/reviews/page.tsx` (active `ink-900` → `moss-700`)
+- `app/admin/businesses/review-queue/page.tsx`
+- `app/inbox/page.tsx` (quick-reply pills)
+- `app/business/[id]/review/page.tsx` (tag pills)
+- `app/business/[id]/contact/page.tsx` (purpose pills)
+- `app/dashboard/leads/page.tsx` (quick-reply pills)
+- `app/dashboard/reviews/page.tsx` (filter pills)
+- `app/notifications/page.tsx`, `app/dashboard/notifications/page.tsx` (filter pills)
+
+### Pass 3 — Remaining focus-less controls (add `man-focus`)
+- `components/header.tsx` (nav links `:91`, dropdown items `:139-148`)
+- `app/dashboard/page.tsx` + `app/dashboard/listing/page.tsx` (underline tabs)
+- toggle switches: `app/dashboard/settings/page.tsx`, `app/account/settings/page.tsx`, `app/account/searches/page.tsx`
+- icon buttons: `app/account/searches/page.tsx`, `app/admin/cert-sources/page.tsx`, `app/dashboard/subscription/page.tsx`, `components/search/FilterSheet.tsx`
+- dashed upload buttons: `app/dashboard/listing/page.tsx`, `app/dashboard/new-listing/page.tsx`, `app/business/[id]/review/page.tsx`, `app/account/lists/page.tsx`
+- option-selection cards: `app/dashboard/verification/page.tsx`
+- stepper circles: `app/dashboard/new-listing/page.tsx`
+- hero save/share/back pills: `app/business/[id]/page.tsx`
+
+> `man/Choice` already uses `man-focusable`; `man/Select` and `man/DatePicker` already show the halo when open — leave them.
+> `_legacy/` excluded.
+
+---
+
+## 4. Out of scope
+- Spacing scale (P1-1), shadow rules (P1-4), demo content (P2-3) — separate items.
+- Converting hand-rolled controls into shared components (a larger refactor) — here we only standardize radius/focus/active-color in place.

--- a/docs/superpowers/specs/2026-06-16-design-polish-consistency-audit.md
+++ b/docs/superpowers/specs/2026-06-16-design-polish-consistency-audit.md
@@ -1,0 +1,123 @@
+# Manaakhah Design Audit — Polish & Consistency
+
+**Date:** 2026-06-16
+**Goal:** Diagnose why Manaakhah reads as "vibe-coded" compared to Fiverr/Upwork, and produce a prioritized, approvable list of fixes.
+**Primary outcome chosen:** Polish & consistency (make it feel professionally built), not a brand-identity overhaul.
+**Scope:** All surfaces — consumer, owner dashboard, admin console.
+
+---
+
+## 1. Executive summary
+
+Manaakhah's design *system* is good. The token set (moss/clay/paper palette, Fraunces + Hanken Grotesk type, the `t-*` scale in `app/globals.css`), the `components/man/primitives.tsx` library, and the owner/admin shells are distinctive and intentional. Many pages — the homepage, About, business profile, the owner and admin shells — speak that language fluently and look bespoke.
+
+The "vibe-coded" feeling does **not** come from a weak design. It comes from **inconsistency**: two design languages collide across the app. Some pages speak fluent "Manaakhah" (`ManCard`, `Tag`, `Rating`, `t-*` typography, raw `var(--*)` tokens). Others — the **search/results page above all** — fall back to generic, un-skinned shadcn + Tailwind defaults (`Card`, `text-muted-foreground`, emoji, spinners). When a user crosses from a polished page into a default-looking one, the eye reads "unfinished." That gap is the tell.
+
+Fiverr and Upwork do not feel vibe-coded because they are *unique* — they feel solid because **every screen speaks one visual language with rigid discipline**. The work here is to bring that same discipline to Manaakhah: unify on one component layer, enforce a spacing scale, replace placeholder UI patterns (emoji, spinners) with real ones, and standardize the color/radius vocabulary — while keeping the good system intact.
+
+---
+
+## 2. What Fiverr/Upwork do that Manaakhah doesn't
+
+These are the *principles* behind their "professionally built" feel — not visual style, but discipline:
+
+1. **One component layer.** A button is the same button everywhere; a card is the same card everywhere. There is never a second, almost-identical version on the next page.
+2. **A strict spacing grid.** Spacing comes from a fixed scale (typically 4/8px increments). Padding and gaps are predictable, so vertical rhythm is consistent screen to screen.
+3. **No emoji as iconography.** A single, consistent icon set is used everywhere. Emoji never appear as UI elements.
+4. **Skeleton loaders, not spinners.** Loading states mirror the shape of the content that's coming, rather than a generic spinning circle.
+5. **Restraint and repetition.** A small number of patterns (one card, one list row, one empty state, one section header) repeated everywhere, rather than each page inventing its own treatment.
+6. **One color vocabulary.** Grays, borders, and surfaces are drawn from a single named set — never two near-identical grays from two different systems on the same screen.
+
+Manaakhah already has the raw materials for all six. They're just applied unevenly.
+
+---
+
+## 3. The tells, with examples
+
+Each item below is a concrete, located instance of one of the principles being broken.
+
+### 3.1 Two component vocabularies
+`app/search/page.tsx` imports shadcn `Card`, `CardContent` (line 19) and `Input` (line 17), and then hand-rolls the business card as a raw `<div>` with inline styles **three separate times** (compact row ~line 221, grid card ~line 265, plus the map thumbnail). Meanwhile the homepage and business profile use `ManCard` from `components/man/primitives.tsx`. Result: subtly different cards on adjacent pages, and a business card that exists in three slightly different hand-built forms instead of one shared component.
+
+### 3.2 Emoji as UI
+`app/search/page.tsx:416` — the empty state renders `<div className="text-6xl mb-4">🔍</div>`. This is the single clearest "AI-generated" giveaway. `lucide-react` is already imported in the same file, so a real icon is one line away.
+
+### 3.3 Generic spinners instead of skeletons
+`app/search/page.tsx:411` (results loading) and `:490` (Suspense fallback) use the classic `animate-spin rounded-full … border-b-2 border-primary` Tailwind spinner with copy like "Finding businesses near you…". The map placeholder (`:11-15`) does the same with "Loading map...". Polished apps render skeleton cards in the results grid shape instead.
+
+### 3.4 Two grays that don't match
+The search page uses shadcn semantic classes — `text-muted-foreground` (lines 412, 417, 428), `border-primary`, `bg-white` — while the rest of the app uses raw tokens (`var(--ink-500)`, `#ffffff`). `text-muted-foreground` maps to `--muted-foreground` (`ink-500` at 40% in HSL), which is close to but not identical to `var(--ink-500)`. Two almost-the-same grays on different pages is exactly what reads as "off."
+
+### 3.5 Magic-number spacing
+Inline padding values are invented per section rather than drawn from a scale:
+- Home "How We Build Trust" cards: `padding: 22` (`app/page.tsx:33`)
+- Category cards: `padding: 18` (`components/home/CategoryGroupGrid.tsx:26`)
+- Owner story card: `padding: 32` (`app/page.tsx:45`)
+- `StatCard`: `padding: 18` (`components/man/primitives.tsx:95`)
+
+Margins (`marginTop: 18/16/12/6/2`) and gaps (`gap-9`, `gap-7`, `gap-2.5`) are similarly ad hoc. There is no spacing scale, so rhythm drifts between sections that should feel related.
+
+### 3.6 Three styling methods at once
+Across the codebase, a single element often combines Tailwind utility classes, an inline `style={{}}` object, and a `t-*` class — e.g. `app/page.tsx:35`: `<div className="t-h4" style={{ color: "var(--ink-900)", marginTop: 12 }}>`. Mixing three styling mechanisms makes spacing and color drift inevitable and is itself a hallmark of generated code.
+
+### 3.7 Radius mismatch
+`components/ui/button.tsx` hardcodes `rounded-[8px]` for every size (lines 6, 22-23), but cards use `borderRadius: 14` and the design token `--radius` is `0.875rem` (14px). 8px buttons sitting inside 14px cards is a small but repeated inconsistency.
+
+### 3.8 Inconsistent shadows
+Three shadow tokens exist (`--shadow-soft`, `--shadow-rest`, `--shadow-lift`) but there's no rule for when each applies. `ManCard` defaults to `--shadow-soft`; some hover states jump straight to `--shadow-lift`; the search cards use `--shadow-rest` on hover. Without a rule, elevation feels arbitrary.
+
+### 3.9 Demo-data bleed (content, lower priority)
+Not strictly visual, but it reinforces the "demo" feel:
+- Hardcoded marketing stats: "110+", "94% Of reviewers return" (`components/home/HeroSearch.tsx:47`)
+- Static dashboard date and copy: "Today · Mon Feb 10" (`app/dashboard/page.tsx:54`)
+- Unsplash stock heroes and invented testimonials ("Yusuf Khan · Famous Kabob") (`app/page.tsx:11, 53-56`)
+
+Flagged for awareness; addressed at P2 since it's content, not design discipline.
+
+---
+
+## 4. Prioritized improvement list (approve item by item)
+
+Organized by impact. P0 items are the ones most responsible for the vibe-coded feel and are high-visibility; work top-down.
+
+### P0 — Biggest offenders, highest visibility
+
+- [ ] **P0-1. Extract one shared `BusinessCard` component.** Replace the three hand-rolled card variants in `app/search/page.tsx` (grid, compact row, map thumbnail) with a single `man/`-based component with a `variant` prop. Reuse it anywhere businesses are listed (search, favorites, profile-related lists).
+- [ ] **P0-2. Migrate the search page off un-skinned shadcn.** Replace bare `Card`/`CardContent`/`Input` usage with `man/primitives` equivalents (or `man/`-skinned wrappers), so search speaks the same language as home and profile.
+- [ ] **P0-3. Kill emoji UI.** Replace the `🔍` empty state (and any other emoji used as icons) with a lucide icon inside a shared `EmptyState` component.
+- [ ] **P0-4. Build a shared `EmptyState` component.** Icon + title + body + optional action button. Use it for search-no-results and anywhere else that needs an empty state, so they're all identical.
+- [ ] **P0-5. Replace spinners with skeletons.** Build a `Skeleton` primitive and skeleton variants of the business card / results grid / map. Use them in place of the `animate-spin` loaders in `app/search/page.tsx` (lines 411, 490) and the map placeholder.
+- [ ] **P0-6. One color vocabulary on the search page.** Replace `text-muted-foreground`, `border-primary`, and `bg-white` with the same `var(--*)` tokens the rest of the app uses. (App-wide, pick one system — raw tokens or shadcn-semantic — and stick to it; the rest of the app already leans on raw tokens, so that's the recommended default.) No two-gray mismatches.
+
+### P1 — Systemic consistency
+
+- [ ] **P1-1. Define and adopt a spacing scale.** Establish tokens (e.g. 4/8/12/16/20/24/32/40) and replace magic-number paddings/margins/gaps. Start with the card paddings called out in §3.5 so related cards match.
+- [ ] **P1-2. Reconcile the `Button` radius.** Align `components/ui/button.tsx` radius to the card/token radius (14px, or a deliberate smaller-but-consistent value), and verify it looks right inside cards.
+- [ ] **P1-3. Pick one styling convention and document it.** Recommended rule: **layout** via Tailwind utilities, **color/typography** via `t-*` + tokens, **inline `style`** only for dynamic/computed values. Capture it in a short `CONTRIBUTING`/`docs` note so new pages don't reintroduce drift.
+- [ ] **P1-4. Define shadow/elevation rules.** Document when each of `--shadow-soft` / `--shadow-rest` / `--shadow-lift` applies (e.g. soft = resting card, lift = hover/raised, rest = interactive list row) and apply consistently.
+
+### P2 — Polish & content
+
+- [ ] **P2-1. Audit remaining pages for the same tells.** Sweep favorites, lists, settings, dashboard sub-pages, and admin pages for stray shadcn defaults, emoji, spinners, and magic-number spacing; fix to match.
+- [ ] **P2-2. Standardize loading/empty/error states app-wide.** Once `EmptyState` and `Skeleton` exist, ensure every async surface uses them rather than ad-hoc treatments.
+- [ ] **P2-3. Replace or clearly label demo content.** Swap hardcoded stats, static dates, and invented testimonials for real data, or mark them as sample data, so the app stops reading as a demo (§3.9).
+
+---
+
+## 5. What to explicitly keep
+
+These are working and should **not** be thrown out in the name of "redesign":
+
+- The **token system** in `app/globals.css` (palette, type scale, shadows, radius) — it's the backbone; we're enforcing it, not replacing it.
+- The **`man/primitives.tsx` library** (`ManCard`, `Tag`, `Rating`, `Avatar`, `StatCard`, `Seal`, `PH`, `Divider`) — extend it, don't abandon it.
+- The **owner and admin shells** (`OwnerShell`, `AdminShell`) — these are already consistent and well-structured.
+- The **Fraunces + Hanken Grotesk pairing** and the moss/clay/paper identity — distinctive and on-brand.
+- The **homepage and business profile** layouts — they're the reference standard the other pages should rise to.
+
+---
+
+## 6. Suggested execution path
+
+The natural first slice of implementation is **P0 as a single coherent piece of work**, because the items reinforce each other: extracting `BusinessCard` (P0-1), building `EmptyState` (P0-4) and `Skeleton` (P0-5), and using them to fix the search page (P0-2, P0-3, P0-5, P0-6) is essentially "bring the search page up to the standard of the homepage." That one slice removes the most visible vibe-coded surface in the app and creates the shared components the rest of the cleanup will reuse.
+
+P1 and P2 then become mechanical sweeps applying the now-established conventions.

--- a/docs/superpowers/specs/2026-06-16-design-polish-consistency-audit.md
+++ b/docs/superpowers/specs/2026-06-16-design-polish-consistency-audit.md
@@ -91,10 +91,10 @@ Organized by impact. P0 items are the ones most responsible for the vibe-coded f
 
 ### P1 — Systemic consistency
 
-- [ ] **P1-1. Define and adopt a spacing scale.** Establish tokens (e.g. 4/8/12/16/20/24/32/40) and replace magic-number paddings/margins/gaps. Start with the card paddings called out in §3.5 so related cards match.
+- [x] **P1-1. Define and adopt a spacing scale.** ✅ Done — `2026-06-16-spacing-scale.md`. Inline magic-number paddings/margins/gaps snapped to the 4px scale; card paddings unified to 20.
 - [x] **P1-2. Reconcile the `Button` radius.** ✅ Done — superseded by the full 4-grid radius scale (`2026-06-16-radius-scale.md`): buttons + inputs at 8px (controls), cards 12px, tiny 4px, pills full.
-- [ ] **P1-3. Pick one styling convention and document it.** Recommended rule: **layout** via Tailwind utilities, **color/typography** via `t-*` + tokens, **inline `style`** only for dynamic/computed values. Capture it in a short `CONTRIBUTING`/`docs` note so new pages don't reintroduce drift.
-- [ ] **P1-4. Define shadow/elevation rules.** Document when each of `--shadow-soft` / `--shadow-rest` / `--shadow-lift` applies (e.g. soft = resting card, lift = hover/raised, rest = interactive list row) and apply consistently.
+- [x] **P1-3. Pick one styling convention and document it.** ✅ Done — `docs/DESIGN_CONVENTIONS.md` consolidates the component layer, styling method, color/radius/spacing scales, focus treatment, pills, elevation, and icon/state rules.
+- [x] **P1-4. Define shadow/elevation rules.** ✅ Done — soft = resting card, rest = raised/interactive, lift = overlay/dropdown/floating. All 14 ad-hoc Tailwind `shadow-*` usages converted to the tokens.
 
 ### P2 — Polish & content
 

--- a/docs/superpowers/specs/2026-06-16-design-polish-consistency-audit.md
+++ b/docs/superpowers/specs/2026-06-16-design-polish-consistency-audit.md
@@ -92,7 +92,7 @@ Organized by impact. P0 items are the ones most responsible for the vibe-coded f
 ### P1 — Systemic consistency
 
 - [ ] **P1-1. Define and adopt a spacing scale.** Establish tokens (e.g. 4/8/12/16/20/24/32/40) and replace magic-number paddings/margins/gaps. Start with the card paddings called out in §3.5 so related cards match.
-- [ ] **P1-2. Reconcile the `Button` radius.** Align `components/ui/button.tsx` radius to the card/token radius (14px, or a deliberate smaller-but-consistent value), and verify it looks right inside cards.
+- [x] **P1-2. Reconcile the `Button` radius.** ✅ Done — superseded by the full 4-grid radius scale (`2026-06-16-radius-scale.md`): buttons + inputs at 8px (controls), cards 12px, tiny 4px, pills full.
 - [ ] **P1-3. Pick one styling convention and document it.** Recommended rule: **layout** via Tailwind utilities, **color/typography** via `t-*` + tokens, **inline `style`** only for dynamic/computed values. Capture it in a short `CONTRIBUTING`/`docs` note so new pages don't reintroduce drift.
 - [ ] **P1-4. Define shadow/elevation rules.** Document when each of `--shadow-soft` / `--shadow-rest` / `--shadow-lift` applies (e.g. soft = resting card, lift = hover/raised, rest = interactive list row) and apply consistently.
 

--- a/docs/superpowers/specs/2026-06-16-form-control-consistency-audit.md
+++ b/docs/superpowers/specs/2026-06-16-form-control-consistency-audit.md
@@ -1,0 +1,108 @@
+# Form Control Consistency Audit & Convention
+
+**Date:** 2026-06-16
+**Parent:** Extends `2026-06-16-design-polish-consistency-audit.md` (this is the P1 "one component layer" work for inputs/controls).
+**Goal:** Eliminate the inconsistent input "selected/focus" states across the app by standardizing every form control on one convention.
+**Trigger:** The home search bar and the search-page field have visibly different selected states (no indicator vs. a moss ring).
+
+---
+
+## 1. The problem
+
+The app currently has **three different input treatments**, and the most common one has no focus indicator at all:
+
+| Treatment | Focus / selected state | Border | Radius | Where |
+|---|---|---|---|---|
+| **A — shadcn ring** | 2px moss ring + 2px offset gap (`focus-visible:ring-2 ring-ring ring-offset-2`) | `border-input` (= `--card-edge`) | `rounded-md` (~7px) | `ui/Input`, `ui/Textarea`, `ui/Select` |
+| **B — custom man** | border turns `--moss-700` on open/checked; **no ring** | dynamic | 10px / 5px / full | `man/Select`, `man/DatePicker`, `man/Choice` |
+| **C — raw inline** | **none** — `outline-none` with no replacement | `--card-edge` (static) or none | 8/10/12/14px | 28+ inline `<input>`/`<textarea>` across the app |
+
+Consequences:
+- **Visible inconsistency** — the home hero search (C, no indicator) vs. the search-page field (A, moss ring) is the same control with two different selected states.
+- **Radius chaos** — rectangular text controls use `rounded-md` (7px), `8px`, `10px`, `12px`, and `14px`.
+- **Accessibility gap** — the 28+ Group-C inputs give keyboard users no focus indicator.
+
+---
+
+## 2. The convention (approved)
+
+**One selected/focus treatment for all text-like controls: moss border + soft halo.**
+
+- **Rest:** `border: 1px solid var(--card-edge)`; background `#ffffff`; radius **10px** (standard fields, textareas, selects, datepicker/select triggers).
+- **Focus / focus-within:** `border-color: var(--moss-700)` + `box-shadow: 0 0 0 3px var(--moss-100)`; `outline: none`. No offset gap.
+- **Search bars** (hero + search page) and other "input-inside-a-bordered-container" patterns: the **container** carries the border and gets the focus treatment via `:focus-within` (because the inner `<input>` is transparent/borderless). Container radius **12px** (a deliberate, consistent search affordance — the only rectangular radius other than 10px).
+- **Checkboxes** keep `rounded-[5px]`, **radios** keep `rounded-full`; both already turn moss when checked. They additionally get the same halo on keyboard focus for a11y.
+
+This unifies Group A and B's "border turns green" language and closes Group C's accessibility gap with a single, on-brand cue.
+
+### Implementation strategy (one source of truth)
+
+Add shared classes to `app/globals.css` so the treatment lives in exactly one place:
+
+```css
+/* Unified form-control treatment */
+.man-field {
+  border: 1px solid var(--card-edge);
+  border-radius: 10px;
+  background: #ffffff;
+}
+.man-field:focus,
+.man-field:focus-visible {
+  outline: none;
+  border-color: var(--moss-700);
+  box-shadow: 0 0 0 3px var(--moss-100);
+}
+/* For controls whose visible border lives on a wrapper (search bars, icon+input rows) */
+.man-field-wrap:focus-within {
+  border-color: var(--moss-700);
+  box-shadow: 0 0 0 3px var(--moss-100);
+}
+```
+
+Then:
+- **shadcn `ui/Input`, `ui/Textarea`, `ui/Select`:** replace the `focus-visible:ring-2 ring-ring ring-offset-2` + `rounded-md` with the `man-field` treatment (border+halo, radius 10px). Keep them as the base components.
+- **Group C raw inputs:** swap each ad-hoc `fieldCls`/`field` constant and inline `outline-none` field for `man-field` (or add `man-field-wrap` to the bordered container for transparent search inputs).
+- **`man/Select`, `man/DatePicker`:** add the halo on open/focus (keep their existing moss border).
+- **`man/Choice`:** add the focus halo for keyboard users.
+
+---
+
+## 3. Full target list (for the batch fix)
+
+### Shared components (change the source → fixes many call sites)
+- `components/ui/input.tsx:13`
+- `components/ui/textarea.tsx:12`
+- `components/ui/select.tsx:12`
+- `components/man/Select.tsx:42-43` (+ open state)
+- `components/man/DatePicker.tsx:59-60`
+- `components/man/Choice.tsx:32-38` (checkbox), `:64-68` (radio)
+
+### Search bars / transparent-input containers (use `man-field-wrap` on the container)
+- `components/home/HeroSearch.tsx:36-40` (home hero — the original complaint)
+- `app/search/page.tsx:215` (uses shadcn `Input` — inherits the fix, verify it reads consistently)
+- `app/inbox/page.tsx:48-49` (search), `:100-102` (compose)
+- `app/help/page.tsx:32-34`
+- `app/claim-business/page.tsx:55-57`
+- `app/admin/businesses/review-queue/page.tsx:42`
+- `app/dashboard/leads/page.tsx:38`
+- `app/dashboard/reviews/page.tsx:65`
+- `components/help/AuthedHelp.tsx:52`
+
+### Inline field constants & raw fields (swap to `man-field`)
+- `app/dashboard/settings/page.tsx:10` (`fieldCls`), used `:58-61`
+- `app/dashboard/listing/page.tsx:16` (`fieldCls`), used `:53-62, 116-118`
+- `app/dashboard/new-listing/page.tsx:16` (`fieldCls`), used `:56-72, 79-81`
+- `app/business/[id]/contact/page.tsx:21-22` (`field`), used `:56-61`
+- `app/admin/businesses/[id]/page.tsx:75` (textarea)
+- `app/admin/support/page.tsx:76` (textarea)
+- `app/dashboard/leads/page.tsx:84` (reply textarea)
+- `app/dashboard/verification/page.tsx:70` (OTP 1-char inputs)
+
+> `_legacy/` is intentionally excluded.
+
+---
+
+## 4. Out of scope (for this pass)
+- Button radius reconciliation (separate P1 item, `2026-06-16-design-polish-consistency-audit.md` P1-2).
+- The app-wide spacing scale (P1-1).
+- Hover states on non-input controls.

--- a/docs/superpowers/specs/2026-06-16-radius-scale.md
+++ b/docs/superpowers/specs/2026-06-16-radius-scale.md
@@ -1,0 +1,34 @@
+# Corner-Radius Scale (4px grid)
+
+**Date:** 2026-06-16
+**Goal:** Every corner radius in the app is a multiple of 4, drawn from one small scale. Harmonizes with the 4/8px spacing grid.
+
+## The scale
+| Token | Value | Used for |
+|---|---|---|
+| `xs` | **4px** | checkboxes, tiny chips, focus-halo corners |
+| `sm` | **8px** | inputs/fields, icon buttons, search containers |
+| `md` | **12px** | buttons, cards, panels, dropdowns, containers |
+| `full` | — | pills, toggles, avatars |
+
+(Buttons and cards both land on 12 — intentional, per decision to keep cards at 12.)
+
+## Mapping (old → new)
+- `5`, `6` → **4**
+- `10` → **8**
+- `14` → **12**
+- `8`, `12` → unchanged
+- `0`, `full`/`999` → unchanged
+
+## The three forms to sweep
+1. **Tailwind config** (`tailwind.config.ts`): currently `lg: var(--radius)` (14), `md: calc(-2)` (12), `sm: calc(-4)` (10). Replace with explicit on-grid values: `sm: "8px"`, `md: "12px"`, `lg: "12px"`. This auto-fixes all `rounded-lg` (×39, 14→12) and `rounded-sm` (×4, 10→8); `rounded-md` (×12) stays 12. Update `--radius` to `0.75rem` (12px) for any external reference and keep `rounded-xl` at its 12px default.
+2. **Arbitrary literals** (`rounded-[Npx]`): `rounded-[10px]`→`rounded-[8px]`; `rounded-[14px]`→`rounded-[12px]`; `rounded-[6px]`→`rounded-[4px]`; `rounded-[5px]`→`rounded-[4px]`. (`[8px]`, `[12px]` unchanged.)
+3. **Inline JS** (`borderRadius:` numbers and `radius={N}`/`radius: N` props): `10`→`8`, `14`→`12`, `6`→`4`; keep `8`, `12`, `0`, `999`.
+
+## CSS class radii (from earlier passes)
+- `.man-field` `border-radius: 10px` → **8px**
+- `.man-focusable` `border-radius: 6px` → **4px**
+
+## Scope
+- `app/` and `components/` (incl. `man` primitives, `Skeleton`, `BusinessCard`). `_legacy/` excluded.
+- After: a grep for `rounded-\[(5|6|10|14)px\]` and `borderRadius: ?(10|14)` and `radius[=:] ?\{?(6|10|14)` must return nothing in scope.

--- a/docs/superpowers/specs/2026-06-16-radius-scale.md
+++ b/docs/superpowers/specs/2026-06-16-radius-scale.md
@@ -7,11 +7,11 @@
 | Token | Value | Used for |
 |---|---|---|
 | `xs` | **4px** | checkboxes, tiny chips, focus-halo corners |
-| `sm` | **8px** | inputs/fields, icon buttons, search containers |
-| `md` | **12px** | buttons, cards, panels, dropdowns, containers |
+| `sm` | **8px** | **controls: buttons + inputs/fields**, icon buttons, search containers |
+| `md` | **12px** | cards, panels, dropdowns, large selection tiles, upload drop-zones |
 | `full` | — | pills, toggles, avatars |
 
-(Buttons and cards both land on 12 — intentional, per decision to keep cards at 12.)
+Buttons and input fields share the 8px **controls** tier so adjacent control rows (e.g. an input + its Search button) have matching corners. Cards/containers sit one step up at 12px. (Large dashed upload drop-zones and selectable method tiles are treated as containers → 12.)
 
 ## Mapping (old → new)
 - `5`, `6` → **4**

--- a/docs/superpowers/specs/2026-06-16-spacing-scale.md
+++ b/docs/superpowers/specs/2026-06-16-spacing-scale.md
@@ -1,0 +1,49 @@
+# Spacing Scale (P1-1) — pragmatic sweep
+
+**Date:** 2026-06-16
+**Goal:** Replace the inline arbitrary "magic number" paddings/margins/gaps with a small consistent scale, unifying card paddings especially. Tailwind's 2px half-step classes (`gap-1.5`, `py-2.5`, …) are an accepted systematic sub-grid and are **left as-is** (pragmatic scope, per decision).
+
+## Scale
+`4 · 8 · 12 · 16 · 20 · 24 · 28 · 32 · 40 · 48` (px). Values ≤2px are kept (optical hairline nudges).
+
+## What to sweep
+Only **inline `style={{}}` spacing** — `padding*`, `margin*`, and `gap` — plus the 4 arbitrary Tailwind literals (`p-[18px]`, `p-[22px]`, `px-[18px]`). 
+
+## What to LEAVE
+- **Absolute positioning** props: `top` / `right` / `bottom` / `left` (e.g. the inset-50 overlay, toggle-knob offsets) — these are layout coordinates, not rhythm.
+- **Tailwind `.5` half-step classes** (`gap-3.5`, `py-2.5`, `px-3.5`, `gap-1.5`, …) — kept.
+- Any value already on the scale.
+
+## Mapping (inline values)
+
+**Padding** (`padding`, `paddingTop/...`, and `p-[Npx]`/`px-[Npx]`/`py-[Npx]`) — card paddings unify to **20**:
+| old | new |
+|---|---|
+| 14 | 16 |
+| 18 | **20** |
+| 22 | **20** |
+| 26 | 24 |
+| 32 | 32 (keep — large feature padding) |
+
+> `padding: 18` and `padding: 22` are overwhelmingly card/panel containers; mapping both to **20** makes the previously-mismatched cards (§3.5 of the design audit: 18/22/32) consistent. Arbitrary literals: `p-[18px]`→`p-5`, `p-[22px]`→`p-5`, `px-[18px]`→`px-5` (Tailwind `5` = 20px).
+
+**Margin / gap / inline offsets** (`margin*`, `gap`) — round to nearest multiple of 4, **ties → down** (crisper rhythm); keep 0/1/2:
+| old | new |
+|---|---|
+| 3 | 4 |
+| 5 | 4 |
+| 6 | 4 |
+| 10 | 8 |
+| 14 | 12 |
+| 18 | 16 |
+| 22 | 20 |
+| 26 | 24 |
+
+## Verify after sweep
+- `grep -rnE "(padding|margin)[A-Za-z]*: ?(3|5|6|10|14|18|22|26)\b" app components` → none (except inside `top/right/bottom/left` positioning, which is fine).
+- `grep -rnE "gap: ?(3|5|6|7|9|10|14|18|22|26)\b" app components` → none.
+- `grep -rnE "\b(p|px|py)-\[(18|22)px\]" app components` → none.
+- typecheck + build clean.
+
+## Scope
+`app/` + `components/`; `_legacy/` excluded.

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -45,9 +45,9 @@ const config: Config = {
         },
       },
       borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
+        sm: "8px",
+        md: "12px",
+        lg: "12px",
       },
     },
   },


### PR DESCRIPTION
Establishes a documented, enforced design system and removes the "vibe-coded" inconsistency, completing **P0** and **P1** of the design audit.

## P0 — Search page brought up to standard
- New shared components: `BusinessCard` (extracted, reused for grid + compact), `EmptyState`, `Skeleton`/`BusinessCardSkeleton`.
- Search page migrated off un-skinned shadcn defaults; removed the 🔍 emoji empty state, the loading spinners (→ skeletons), and mismatched grays.

## P1 — Systemic consistency
- **Form-control focus** — one moss-halo selected state across ~20 inputs + 8 search containers via shared `.man-field`/`.man-field-wrap` classes (previously 3 different treatments incl. 28+ inputs with *no* focus indicator).
- **Buttons & controls** — unified focus halo (`.man-focus`) on every interactive control (~14 types had none); filter-pill active color unified to moss.
- **Radius (P1-2)** — one 4px-grid scale: controls (buttons + inputs) 8px, cards 12px, tiny 4px, pills full.
- **Spacing (P1-1)** — inline magic-number paddings/margins/gaps snapped to a 4px scale; card paddings unified to 20px.
- **Elevation (P1-4)** — all shadows routed through the 3 tokens (`soft`/`rest`/`lift`); removed 14 ad-hoc Tailwind shadows.
- **Convention doc (P1-3)** — `docs/DESIGN_CONVENTIONS.md` is the single living reference so future work doesn't drift.

Specs/plans for each piece live in `docs/superpowers/specs/2026-06-16-*`.

## Verification
- `tsc --noEmit` clean; `npm run build` compiles (89 pages).
- Runtime smoke-tested (home, search, dashboard, business profile, auth all 200, no runtime errors).
- Each change went through spec + code-quality review; grep gates confirm no off-grid radii/spacing, no emoji/spinners, no stray shadow utilities.

## Not included (deferred)
P2 — remaining-page sweep, app-wide loading/empty/error standardization, and replacing demo/placeholder content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)