### PR TITLE
fix: Netlify deployment — remove standalone output, add Next.js plugin

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  command = "npm run build"
+  publish = ".next"
+
+[build.environment]
+  SKIP_ENV_VALIDATION = "true"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,7 +14,6 @@ jiti.import("./lib/env.ts");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: "standalone",
   images: {
     remotePatterns: [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "manakhaah",
+  "name": "minara",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "manakhaah",
+      "name": "minara",
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
@@ -48,6 +48,7 @@
         "zod": "^4.3.5"
       },
       "devDependencies": {
+        "@netlify/plugin-nextjs": "^5.15.12",
         "@types/bcryptjs": "^2.4.6",
         "@types/cheerio": "^0.22.35",
         "@types/leaflet": "^1.9.21",
@@ -1732,6 +1733,16 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@netlify/plugin-nextjs": {
+      "version": "5.15.12",
+      "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.15.12.tgz",
+      "integrity": "sha512-eydPd4gtc/OJOx9IbIJ5CRrC5K3rLxfEQS/S/fRNEAAT0qFvPoQVy23VdK3jRXKFJWXdCRl6ZudWLEZECQPSRQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@next/env": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
+    "@netlify/plugin-nextjs": "^5.15.12",
     "@types/bcryptjs": "^2.4.6",
     "@types/cheerio": "^0.22.35",
     "@types/leaflet": "^1.9.21",


### PR DESCRIPTION
## Problem
`output: "standalone"` in `next.config.mjs` is for Docker/self-hosted only. On Netlify it generates no redirect rules, causing every page to 404.

## Fix
- Remove `output: "standalone"` from `next.config.mjs`
- Add `netlify.toml` with build config and `@netlify/plugin-nextjs`
- `@netlify/plugin-nextjs` handles SSR routing on Netlify

This was missed in the PR #5 merge — the commit was added after the PR was created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)